### PR TITLE
Fix oom mask

### DIFF
--- a/.claude/specs/bottom_up/design.md
+++ b/.claude/specs/bottom_up/design.md
@@ -1,0 +1,261 @@
+# Design Document: Bottom-Up Training Algorithm
+
+## Overview
+
+The bottom-up training algorithm implements a multi-round inference strategy that iteratively refines posterior approximations. It alternates between training local likelihood estimators `p(y|theta)` and global posterior estimators `p(theta, z|y)`, progressively improving inference quality. This design integrates with existing TFMPE infrastructure by reusing `fit_fast()` for each training round and leveraging the Tokens API for token restructuring between rounds.
+
+## Steering Document Alignment
+
+### Technical Standards (tech.md)
+- **Type Annotations**: Full jaxtyping support with clear function signatures using `Array`, `PRNGKeyArray`, `Callable` types
+- **Functions over Classes**: Bottom-up training implemented as a standalone function, not a class hierarchy
+- **Code Quality**: Reuses existing `fit_fast()` and `cfm_loss()` rather than reimplementing; clear, testable logic with <80 char lines
+- **JAX Integration**: Non-jittable wrapper around jittable `fit_fast()` calls; documents this limitation explicitly
+
+### Project Structure (structure.md)
+- **Location**: New function in `tfmpe/estimators/training.py` alongside `fit_fast()`
+- **Tests**: E2E test in `test/test_estimators/test_e2e_training.py` in new test class
+- **No new files**: Reuses existing infrastructure; only adds function to training.py
+
+## Code Reuse Analysis
+
+### Existing Components to Leverage
+- **`fit_fast()`** (training.py:86-228): Core training loop using `nnx.scan` with batched CFM loss; called once per round
+- **`cfm_loss()`** (training.py:35-83): Continuous Flow Matching loss computation; reused unchanged
+- **`TFMPE` class** (tfmpe.py): Sampling and log probability methods; round 0 samples from prior, later rounds sample from posterior
+- **`Tokens.from_pytree()`**: Creates token structures from PyTree dicts with labeller support
+- **`Tokens.decode_keys()`**: Extracts only needed parameter keys without full reconstruction
+- **`Labeller.for_keys()`**: Creates labeller instances for specified key sets
+- **Test data generation** (test_e2e_training.py): `create_hierarchical_gaussian_data()` provides structured test data
+
+### Integration Points
+- **TFMPE API**: Uses `sample_posterior()` for parameter sampling, `log_prob_posterior_samples()` for log probability
+- **Training loop**: Each round calls `fit_fast()` with appropriate token parameters and context
+- **Token management**: Decodes samples from one round, re-encodes for next round's training objective
+- **Test infrastructure**: Reuses existing E2E test patterns, assertions, and data creation
+
+## Architecture
+
+```mermaid
+graph TD
+    A["Round 0:<br/>Initialize"] -->|sample prior| B["Sample theta ~ p(theta)"]
+    B -->|simulate| C["Sample y ~ simulator(theta)"]
+    C -->|fit_fast| D["Train p-y|theta"]
+    D -->|decode samples| E["Extract theta samples"]
+
+    E -->|Round 1+: Refine| F["Sample theta ~ p(theta|y_obs)<br/>from previous round"]
+    F -->|new data| G["Sample y ~ p(y|theta)"]
+    G -->|fit_fast| H["Train p(y|theta)<br/>local likelihood"]
+    H -->|decode| I["Extract improved theta estimates"]
+
+    I -->|restructure tokens| J["Re-encode as<br/>params + context"]
+    J -->|fit_fast| K["Train p(theta,z|y)<br/>global posterior"]
+    K -->|loop| L["Next round or finish"]
+
+    style A fill:#e1f5ff
+    style D fill:#fff3e0
+    style H fill:#fff3e0
+    style K fill:#f3e5f5
+    style L fill:#e8f5e9
+```
+
+## Components and Interfaces
+
+### Component 1: `fit_bottom_up()` Function
+
+**Purpose**: Execute multi-round bottom-up training, alternating between local likelihood and global posterior estimators.
+
+**Signature**:
+```python
+def fit_bottom_up(
+    tfmpe: TFMPE,
+    y_obs: Dict[str, Array],
+    simulator_fn: Callable[[Dict[str, Array]], Dict[str, Array]],
+    prior_fn: Callable[[PRNGKeyArray], Dict[str, Array]],
+    n_rounds: int,
+    n_samples_per_round: int,
+    opt: nnx.Optimizer,
+    n_iter_per_round: int,
+    rng: PRNGKeyArray,
+) -> Tuple[TFMPE, List[Tuple[Array, Array]]]:
+    """
+    Execute multi-round bottom-up training.
+
+    Parameters
+    ----------
+    tfmpe : TFMPE
+        Initial TFMPE instance for training
+    y_obs : Dict[str, Array]
+        Observed data, shape per key (*sample_shape, *event_shape, *batch_shape)
+    simulator_fn : Callable
+        Function that generates y ~ p(y|theta) given theta dict
+    prior_fn : Callable
+        Function that samples theta ~ p(theta) given PRNG key
+    n_rounds : int
+        Number of training rounds (≥1)
+    n_samples_per_round : int
+        Number of parameter samples to draw per round
+    opt : nnx.Optimizer
+        NNX optimizer for TFMPE training
+    n_iter_per_round : int
+        Iterations of fit_fast per training round
+    rng : PRNGKeyArray
+        PRNG key for sampling
+
+    Returns
+    -------
+    Tuple[TFMPE, List[Tuple[Array, Array]]]
+        (trained_tfmpe, all_round_losses) where all_round_losses is list of
+        (train_losses, val_losses) tuples, one per round
+    """
+```
+
+**Dependencies**:
+- `fit_fast()` from training.py
+- `TFMPE` class and its methods
+- `Tokens.from_pytree()`, `Tokens.decode_keys()`
+- `Labeller.for_keys()`
+- JAX PRNG utilities, nnx
+
+**Reuses**:
+- `fit_fast()` for each training step
+- Existing TFMPE sampling and log probability methods
+- Tokens API for encode/decode
+
+### Component 2: Round 0 Initialization Logic
+
+**Purpose**: Generate initial training data by sampling from prior and simulator.
+
+**Algorithm**:
+1. Sample `n_samples` parameters from `prior_fn(rng)`
+2. Simulate observations `y ~ simulator_fn(theta)` for each parameter sample
+3. Create token structures for training `p(y|theta)`:
+   - Context tokens: observations `y`
+   - Parameter tokens: parameters `theta`
+4. Call `fit_fast()` with these tokens
+
+**Key Implementation Detail**: No validation set in round 0 (or use empty/single sample); only train loss tracking
+
+### Component 3: Rounds 1+ Refinement Logic
+
+**Purpose**: Iteratively refine posteriors by training local likelihood then global posterior.
+
+**Algorithm per round**:
+1. **Posterior Sampling**:
+   - Sample `n_samples` parameter sets from previous round's posterior: `theta ~ p(theta|y_obs)`
+   - Use TFMPE's `sample_posterior()` with observed context
+
+2. **Local Likelihood Training**:
+   - For each theta sample, simulate new observations: `y ~ simulator_fn(theta)`
+   - Create tokens: context=y, params=theta
+   - Call `fit_fast()` to train `p(y|theta)` on newly simulated data
+
+3. **Global Posterior Training**:
+   - Decode improved parameter estimates from local likelihood training
+   - Re-encode tokens for global posterior objective:
+     - Context: observed `y_obs` (fixed)
+     - Params: theta + z (latent variables)
+   - Call `fit_fast()` to train `p(theta, z | y_obs)`
+
+4. **Loss Tracking**: Collect train/val losses from each `fit_fast()` call
+
+**Key Implementation Detail**: Token restructuring handled by creating new Tokens objects with reordered keys; no manual data copying
+
+## Data Models
+
+### Input Structure
+```
+y_obs : Dict[str, Array]
+    Observed context data with shape (*sample_shape, *event_shape, *batch_shape)
+
+simulator_fn output : Dict[str, Array]
+    Simulated observations matching y_obs structure and shapes
+
+prior_fn output : Dict[str, Array]
+    Parameter samples matching TFMPE's parameter expectations
+```
+
+### Token Structures
+
+**Round 0 - Local Likelihood Tokens**:
+```
+context_tokens: Tokens
+    - Keys: observation names from y_obs (e.g., 'y')
+    - data: stacked simulated observations
+    - slices: metadata for observation indices
+
+param_tokens: Tokens
+    - Keys: parameter names from prior_fn (e.g., 'theta', 'mu', 'sigma')
+    - data: stacked parameter samples
+    - slices: metadata for parameter indices
+```
+
+**Rounds 1+ - Global Posterior Tokens**:
+```
+context_tokens: Tokens
+    - Keys: observation names (e.g., 'y') from y_obs
+    - data: fixed observed context
+
+param_tokens: Tokens
+    - Keys: parameter + latent variable names (e.g., 'theta', 'z')
+    - data: restructured to include latent encoding
+    - Note: latent 'z' added via Tokens.from_pytree() with extended key set
+```
+
+### Return Value
+```
+Tuple[TFMPE, List[Tuple[Array, Array]]]
+    - TFMPE: Trained estimator after all rounds
+    - List of losses: Per-round (train_losses, val_losses) where each is Array shape (n_iter,)
+```
+
+## Error Handling
+
+### Error Scenarios
+
+1. **Invalid Round Count**
+   - **Condition**: `n_rounds < 1`
+   - **Handling**: Raise `ValueError("n_rounds must be ≥1")`
+   - **User Impact**: Clear error message in test output
+
+2. **Shape Mismatch Between Rounds**
+   - **Condition**: Parameter shapes change between simulator and prior_fn outputs
+   - **Handling**: Let `Tokens.from_pytree()` raise with clear error about shape mismatch
+   - **User Impact**: Identifies simulator/prior inconsistency early
+
+3. **NaN/Inf in Losses**
+   - **Condition**: `fit_fast()` returns non-finite losses (divergence)
+   - **Handling**: Propagate to E2E test assertions; test will fail with clear message
+   - **User Impact**: Test catches training instability; test output shows which round failed
+
+4. **Missing Keys in Token Decoding**
+   - **Condition**: `decode_keys()` called with keys not in token structure
+   - **Handling**: Let `decode_keys()` raise `KeyError` with list of valid keys
+   - **User Impact**: Development-time error; helps catch algorithm logic bugs
+
+## Testing Strategy
+
+### Unit Testing
+- **Not planned**: `fit_bottom_up()` is integration-level; no separate unit tests
+- **Rationale**: Logic is straightforward sequencing of tested components (`fit_fast()`, TFMPE methods)
+
+### Integration Testing
+- **E2E Test Class**: `TestE2ETrainingBottomUp` in `test_e2e_training.py`
+- **Test Data**: Reuse `create_hierarchical_gaussian_data()` with 2-3 rounds
+- **Assertions**:
+  - All losses are finite across all rounds
+  - Train loss doesn't catastrophically diverge (no huge spikes)
+  - Returned TFMPE is valid (can call `sample_posterior()`)
+  - Loss shape is correct for each round: `(n_iter,)` per round
+
+### End-to-End Testing
+- **Scenario 1**: Single round (n_rounds=1) matches behavior of direct `fit_fast()` call
+- **Scenario 2**: Multi-round training (n_rounds=3) completes without divergence
+- **Scenario 3**: Loss shapes and finite-value checks work for all rounds
+
+## Implementation Notes
+
+1. **Non-Jittable**: `fit_bottom_up()` uses Python loops for rounds; each `fit_fast()` call is jitted internally
+2. **Token Restructuring**: New Tokens objects created via `from_pytree()` for each round; no manual slicing/indexing
+3. **PRNG Management**: Split RNG key for each round and `fit_fast()` call (standard JAX pattern)
+4. **Validation Data**: For simplicity, first implementation uses empty validation set or reuses training data; refinement in future

--- a/.claude/specs/bottom_up/requirements.md
+++ b/.claude/specs/bottom_up/requirements.md
@@ -1,0 +1,72 @@
+# Requirements Document: Bottom-Up Training Algorithm
+
+## Introduction
+
+The bottom-up training algorithm is a multi-round inference strategy that iteratively refines posterior approximations by training local likelihood estimators and global posterior estimators in alternating rounds. This feature brings the proven multi-round training approach from the legacy SFMPE implementation to the new TFMPE framework, enabling more sophisticated hierarchical model training.
+
+## Alignment with Package Vision
+
+This feature supports TFMPE's goal of providing flexible, efficient probabilistic inference tools by enabling iterative refinement of posterior approximations. Bottom-up training represents a key training paradigm from the legacy codebase that improves posterior quality compared to single-pass training, making it essential for production inference workflows.
+
+## Requirements
+
+### Requirement 1: E2E Test Implementation
+
+**User Story:** As a developer, I want an E2E test that validates bottom-up training works correctly, so that I have confidence the implementation is correct and can refactor safely.
+
+#### Acceptance Criteria
+
+1. WHEN the E2E test runs THEN it SHALL reuse the existing hierarchical Gaussian test data from `test_e2e_training.py`
+2. WHEN training completes THEN the losses (both train and validation) SHALL be finite for all iterations
+3. WHEN comparing training loss across rounds THEN the loss SHOULD generally decrease or remain stable (no catastrophic divergence)
+4. WHEN the test completes THEN it SHALL return a trained TFMPE instance
+
+### Requirement 2: Bottom-Up Algorithm Core Logic
+
+**User Story:** As a researcher, I want to train local likelihood estimators followed by global posteriors, so that I can achieve iterative refinement of inference approximations.
+
+#### Acceptance Criteria
+
+1. WHEN round 0 executes THEN the system SHALL train `p(y|theta)` on sampled prior-predictive data
+2. WHEN subsequent rounds execute THEN the system SHALL:
+   - Decode previous posterior samples to get improved parameter estimates
+   - Re-encode for training the local likelihood with new data
+   - Train global posterior `p(theta,z|y)` on structured data
+3. IF parameters and observations are available THEN the system SHALL handle token restructuring without unnecessary copying
+
+### Requirement 3: Token Encoding and Decoding Between Rounds
+
+**User Story:** As an implementer, I want to encode and decode tokens between rounds, so that I can restructure data for local likelihood vs. global posterior training.
+
+#### Acceptance Criteria
+
+1. WHEN decoding parameter samples THEN the system SHALL use `tokens.decode_keys()` to extract only needed parameters without full reconstruction
+2. WHEN re-encoding decoded parameters into new token structure THEN the system SHALL use `Tokens.from_pytree()` with appropriate keys and labeller configuration
+3. WHEN the training objective switches (local likelihood ↔ global posterior) THEN the system SHALL correctly map which keys are parameters vs. observations
+4. WHEN encoding/decoding THEN the system SHALL be consistent with TFMPE's posterior sampling and log probability methods
+
+### Requirement 4: Integration with Existing TFMPE APIs
+
+**User Story:** As a user, I want bottom-up training to work with TFMPE, `fit_fast`, and existing test infrastructure, so that it fits naturally into the training pipeline.
+
+#### Acceptance Criteria
+
+1. WHEN bottom-up training executes THEN it SHALL use `fit_fast()` internally for each round's training step
+2. IF loss computation is needed THEN the system SHALL reuse `cfm_loss()` from `training.py`
+3. WHEN the test runs THEN it SHALL integrate with the existing test data generation and assertion patterns
+4. WHEN the feature is not jittable THEN the system SHALL clearly document this limitation
+
+## Non-Functional Requirements
+
+### Performance
+- Training should not require full dataset duplication between rounds
+- Token restructuring should be efficient (leveraging views/slices where possible)
+
+### Usability
+- API should be clear about when to use bottom-up vs. single-pass `fit_fast()` training
+- Documentation should explain the multi-round workflow and parameter flow
+
+### Maintainability
+- Code should follow TFMPE patterns: type annotations, numpy-style docstrings, <80 char lines
+- Logic should be testable in isolation from JIT compilation concerns
+- Should reuse existing `fit_fast()` and loss functions rather than reimplementing

--- a/.claude/specs/bottom_up/tasks.md
+++ b/.claude/specs/bottom_up/tasks.md
@@ -1,0 +1,187 @@
+# Implementation Plan: Bottom-Up Training Algorithm
+
+## Task Overview
+
+Implementation follows a test-driven approach: first write the E2E test to establish expected behavior, then implement the algorithm incrementally to make the test pass. The approach prioritizes completing a working end-to-end test before implementation details, enabling rapid iteration and validation.
+
+## Steering Document Compliance
+
+- **Functions over Classes** (tech.md): `fit_bottom_up()` is a standalone function, not a class
+- **Type Annotations** (tech.md): Full jaxtyping with `Array`, `PRNGKeyArray`, `Callable` types
+- **Code Quality** (tech.md): <80 char lines, reuse existing components, clear logic
+- **Project Structure** (structure.md): Single file addition to `tfmpe/estimators/training.py`; tests in existing `test_e2e_training.py`
+
+## Atomic Task Requirements
+
+Each task is scoped to 1-3 related files, completable in 15-30 minutes, with a single testable outcome.
+
+## Tasks
+
+### Task 1: Create E2E Test for Bottom-Up Training (TEST FIRST)
+
+- [x] 1. Write `TestE2ETrainingBottomUp` test class in test_e2e_training.py
+  - File: `test/test_estimators/test_e2e_training.py`
+  - Create new test class `TestE2ETrainingBottomUp` after existing `TestE2ETrainingFast` class
+  - Add test method `test_fit_bottom_up_trains_successfully()` that:
+    - Uses `create_hierarchical_gaussian_data()` to generate 2 rounds of data (n_samples=10 per round)
+    - Calls `fit_bottom_up(tfmpe, y_obs, simulator_fn, prior_fn, n_rounds=2, n_samples_per_round=10, opt, n_iter=5, rng)`
+    - Asserts returned TFMPE is valid (not None, has expected attributes)
+    - Asserts losses is list of 2 tuples (one per round)
+    - Asserts all losses are finite: `jnp.all(jnp.isfinite(losses[i][j]))` for each round and train/val pair
+  - Add test method `test_fit_bottom_up_loss_decreases()` that:
+    - Verifies no catastrophic divergence by checking train loss in later iterations < 10x first iteration per round
+  - Add minimal test helper `create_simulator_fn()` that wraps existing model simulator
+  - Add minimal test helper `create_prior_fn()` that returns sampled parameters from prior
+  - _Requirements: 1.1_
+  - _Leverage: test/test_estimators/test_e2e_training.py (existing test patterns), tfmpe/preprocessing/tokens.py_
+
+### Task 2: Implement Core `fit_bottom_up()` Function Skeleton
+
+- [x] 2. Implement `fit_bottom_up()` with corrected signature
+  - File: `tfmpe/estimators/training.py`
+  - **Final Signature**:
+    ```python
+    def fit_bottom_up(
+        tfmpe: TFMPE,
+        y_obs: Dict[str, Array],
+        simulator_fn: Callable[[PRNGKeyArray, Dict, int], Dict],
+        prior_fn: Callable[[PRNGKeyArray, int, int], Dict],
+        local_fn: Callable[[PRNGKeyArray, Dict, int], Dict],
+        global_names: List[str],
+        n_groups: int,
+        n_rounds: int,
+        n_samples_per_round: int,
+        n_val_samples: int,
+        opt: nnx.Optimizer,
+        n_iter_per_round: int,
+        rng: PRNGKeyArray,
+        independence: Independence,
+    ) -> Tuple[TFMPE, List[Tuple[Array, Array, Array, Array]]]:
+    ```
+  - Key aspects:
+    - `global_names`: List of parameter names that are global (non-local)
+    - `n_val_samples`: Configurable validation sample count
+    - Return type: List of 4-tuples (train_loss_local, val_loss_local, train_loss_global, val_loss_global)
+    - Raises NotImplementedError if n_rounds > 1
+  - Imports: combine_tokens from tfmpe.preprocessing.combine
+  - Purpose: Establish correct function interface matching legacy algorithm
+
+### Task 3: Implement Round 0 (Two-fit with n=1 local, then n=n_groups)
+
+- [x] 3. Implement Round 0 in `fit_bottom_up()` function
+  - File: `tfmpe/estimators/training.py`
+  - **Step 3a - First fit: Train p(y|theta) with n=1 local**:
+    - Sample theta from prior with n=1
+    - Simulate y observations with n=1
+    - Create tokens: params=theta, context=y
+    - Call fit_fast() with n_val_samples validation samples
+    - Store: train_loss_local, val_loss_local
+  - **Step 3b - Prepare data for second fit: Generate theta_full, sample z**:
+    - Extract globals: theta_global = {k: v for k, v in theta if k in global_names}
+    - Generate locals with n=n_groups: theta_local_expanded = local_fn(rng, theta_global, n_groups)
+    - Combine: theta_full = {**theta_global, **theta_local_expanded}
+    - Expand y to n_groups via broadcasting
+    - Sample z via tfmpe.sample_posterior with context=theta_full, params=y_template
+  - **Step 3c - Second fit: Train p(theta,z|y) with n=n_groups**:
+    - Create param tokens from theta_full
+    - Create context tokens from sampled z
+    - Do NOT use combine_tokens() - use theta_full and z_full directly
+    - Call fit_fast() with n_val_samples validation samples
+    - Store: train_loss_global, val_loss_global
+  - Return 4-tuple: (train_loss_local, val_loss_local, train_loss_global, val_loss_global)
+  - Purpose: Full Round 0 implementation with two-fit pattern matching legacy algorithm
+
+### Task 4: Implement Rounds 1+ (Currently NotImplementedError)
+
+- [ ] 4. Round 1+ implementation deferred
+  - File: `tfmpe/estimators/training.py`
+  - **Current Status**: Function raises NotImplementedError if n_rounds > 1
+  - **Future Work**: Implement iterative refinement similar to Round 0 but with:
+    - Posterior sampling from previous round instead of prior sampling
+    - Same two-fit pattern (local n=1, then global n=n_groups)
+  - Purpose: Support multi-round training (deferred for MVP)
+
+### Task 5: Finalize and Debug Integration
+
+- [ ] 5. Complete `fit_bottom_up()` implementation and fix shape issues
+  - File: `tfmpe/estimators/training.py`
+  - **Current implementation status**:
+    - Function signature: ✓ Correct
+    - Round 0 logic: ✓ Implemented
+    - Validation: ✓ NotImplementedError for n_rounds > 1
+    - Return value: ✓ 4-tuple losses
+  - **Known issues to fix**:
+    - Shape mismatch in transformer embedding (combining tokens from n=1 and n=n_groups)
+    - Solution: Remove combine_tokens() calls in second fit, use theta_full and z_full directly as created
+  - **Testing**: Run E2E test and fix shape mismatches
+  - Purpose: Complete MVP implementation (Round 0 only) with passing E2E test
+  - _Requirements: 4.1, 3.1_
+
+### Task 6: Run E2E Test and Debug Integration Issues
+
+- [ ] 6. Execute E2E test and fix integration issues
+  - Files: `test/test_estimators/test_e2e_training.py`, `tfmpe/estimators/training.py`
+  - Run: `python -m pytest test/test_estimators/test_e2e_training.py::TestE2ETrainingBottomUp::test_fit_bottom_up_trains_successfully -xvs`
+  - Expected failures/issues:
+    - Import errors: Add missing imports in training.py (e.g., Labeller, Tokens)
+    - Shape mismatches: Debug simulator_fn output shapes vs. expected token shapes
+    - PRNG key management: Fix key splitting if needed
+    - Token reconstruction: Verify decode/encode consistency
+  - Debug by:
+    - Adding print statements for token shapes and data structure
+    - Checking y_simulated structure matches y_obs keys
+    - Validating theta_samples dict keys match labeller expectations
+  - Stop when test runs without import/attribute errors (test assertions may still fail)
+  - Purpose: Identify and fix integration issues before final validation
+  - _Requirements: 1.1_
+  - _Leverage: pytest runner, existing test patterns_
+
+### Task 7: Validate Loss Computation and Convergence
+
+- [ ] 7. Fix loss computation and verify convergence behavior
+  - Files: `tfmpe/estimators/training.py`, `test/test_estimators/test_e2e_training.py`
+  - Run full E2E test: `python -m pytest test/test_estimators/test_e2e_training.py::TestE2ETrainingBottomUp -xvs`
+  - Debug assertions:
+    - If losses is wrong type/shape: Fix all_losses construction in loop
+    - If losses are NaN: Check token creation (all keys present, shapes consistent)
+    - If losses diverge catastrophically: Reduce learning rate in test setup or n_iter
+    - If test passes but seems wrong: Verify loss values make sense (should decrease over iterations within each round)
+  - Verify test_fit_bottom_up_loss_decreases passes (no 10x divergence per round)
+  - Add assertion for losses list length: `len(all_losses) == n_rounds`
+  - Purpose: Ensure training is numerically stable and converging
+  - _Requirements: 1.2, 1.3_
+  - _Leverage: cfm_loss() validation patterns_
+
+### Task 8: Add Documentation and Comments
+
+- [ ] 8. Add inline documentation and docstring enhancements
+  - File: `tfmpe/estimators/training.py`
+  - Add inline comments explaining:
+    - Token creation for each round (why context vs params)
+    - PRNG key splitting strategy
+    - Difference between local likelihood and global posterior objectives
+    - Non-jittable nature and why (Python loop over rounds)
+  - Enhance docstring with:
+    - Note about non-jittable behavior
+    - Example usage section showing typical call pattern
+    - Description of returned loss structure
+  - Add section in docstring about when to use fit_bottom_up vs fit_fast (multi-round refinement scenario)
+  - Purpose: Make implementation maintainable and usable
+  - _Requirements: 4.1_
+  - _Leverage: fit_fast() docstring as reference_
+
+---
+
+## Testing Approach
+
+1. **Test-First**: Task 1 writes E2E test before implementation
+2. **Iterative Debugging**: Tasks 3-5 implement incrementally; Task 6 runs test and fixes issues
+3. **Validation**: Task 7 verifies loss behavior and convergence
+4. **Integration**: Tasks verify end-to-end flow with real TFMPE and hierarchical Gaussian data
+
+## Expected Implementation Complexity
+
+- **Straightforward Sequential Logic**: No complex algorithms; reuse existing fit_fast and TFMPE methods
+- **Token API Mastery Required**: Understanding Tokens.from_pytree(), decode_keys(), and Labeller is critical
+- **PRNG Management**: Standard JAX pattern; split key per round and fit_fast call
+- **Minimal New Code**: ~100-150 lines of fit_bottom_up implementation (rest is existing component reuse)

--- a/.claude/specs/estimator/design.md
+++ b/.claude/specs/estimator/design.md
@@ -1,0 +1,276 @@
+# Design Document: Tokenized Flow Matching Estimator (TFMPE)
+
+## Overview
+
+TFMPE is a unified estimator class combining sampling and log probability computation for flow matching-based posterior estimation. It consolidates functionality previously split between `StructuredCNF` and `SFMPE` in the legacy codebase, integrating with the new Token-based preprocessing system. The design emphasizes clarity, maintainability, and jittability of training loops.
+
+## Steering Document Alignment
+
+### Technical Standards (tech.md)
+- Uses JAX for numerical computing with explicit type annotations via jaxtyping
+- Implements vectorized operations with vmap over samples
+- Follows function/typing patterns over classes/inheritance
+- Maintains line length ≤ 80 characters
+- No dead or duplicated code; helper functions extracted for complex implementations
+
+### Project Structure (structure.md)
+- Core estimator in `tfmpe/estimators/tfmpe.py`
+- Supporting utilities in `tfmpe/estimators/ode.py` (ODE helpers)
+- Training loops in `tfmpe/estimators/training.py`
+- Tests mirror source structure in `test/estimators/`
+- Benchmarks in `test/benchmark/`
+
+## Code Reuse Analysis
+
+### Existing Components to Leverage
+- **Token preprocessing** (tfmpe/preprocessing/tokens.py): Container for flattened data, labels, masks, slices metadata
+- **TokenGenerator** (tfmpe/preprocessing/generator.py): Memory-efficient batch generation
+- **Transformer network** (tfmpe/nn/transformer/): Vector field implementation for Token inputs
+- **JAX utilities**: `jax.experimental.ode.odeint`, vmap, jit for ODE solving and compilation
+- **Legacy reference** (sfmpe_legacy/): FFJORD implementation, CFM loss, fit_model_no_branch patterns
+
+### Integration Points
+- **Accepts**: Token-formatted data with flattened parameters, labels, masks, independence specs
+- **Produces**: Posterior samples and log probabilities in Token format
+- **Training**: Works with optimizers (optax) and PRNG keys for stochastic training
+
+## Architecture
+
+```mermaid
+graph TD
+    A["ODE Helpers"] -->|solve_forward| B["TFMPE"]
+    A -->|solve_backward| B
+    A -->|solve_augmented| B
+    B -->|sample_posterior| C["Posterior Samples"]
+    B -->|log_prob_posterior_samples| D["Log Probabilities"]
+    E["Vector Field Network"] -->|f_theta| A
+    F["Base Distribution"] -->|sample| B
+    G["Training Data Tokens"] -->|fit_fast| H["Training Loop"]
+    G -->|fit_memory_efficient| H
+    H -->|CFM Loss| I["Trained TFMPE"]
+```
+
+## Components and Interfaces
+
+### Component 1: ODE Solving Helpers (`tfmpe/estimators/ode.py`)
+
+**Purpose:** Encapsulate ODE solving logic for forward/backward trajectories used in sampling and log probability computation.
+
+**Key Functions:**
+- `solve_forward_ode(vf_fn, x0, solver, time_span, rtol, atol) -> Array`
+  - Solves forward ODE from t=0 to t=1 for sampling using Diffrax solver
+  - Returns final state shape (*x0.shape)
+  - Solver: diffrax solver instance (e.g., Dopri5)
+
+- `solve_backward_ode(vf_fn, x1, solver, time_span, rtol, atol) -> Array`
+  - Solves backward ODE from t=1 to t=0 for log probability using Diffrax
+  - Returns final state shape (*x1.shape)
+  - Solver: diffrax solver instance
+
+- `solve_augmented_ode(vf_fn, x0, solver, time_span, rtol, atol) -> Tuple[Array, Scalar]`
+  - Solves augmented ODE [x, log_det_Jacobian] using Diffrax
+  - Returns (final_x, final_log_det_jacobian)
+  - Uses Diffrax's native adjoint-based trace estimation
+
+- `batch_solve_forward_ode(vf_fn, x0_batch, solver, ...) -> Array`
+  - Vmapped version for batch of samples using Diffrax
+  - Handles per-sample ODE solving efficiently
+
+**Dependencies:** diffrax (ODE solver), jax.numpy, Vector field network
+
+**Reuses:** Legacy implementation patterns from sfmpe_legacy/sfmpe/structured_cnf.py (adapted for Diffrax API)
+
+### Component 2: TFMPE Core Class (`tfmpe/estimators/tfmpe.py`)
+
+**Purpose:** Unified interface for sampling and log probability computation with integrated ODE solving.
+
+**Class Structure:**
+```python
+class TFMPE:
+    def __init__(
+        self,
+        vf_network: TransformerNetwork,
+        base_dist_fn: Callable,  # samples from base distribution
+        ode_solver_kwargs: dict,  # rtol, atol, num_steps
+    ) -> None
+
+    def sample_posterior(
+        self,
+        context: Token,
+        num_samples: int,
+        rng: PRNGKeyArray,
+    ) -> Token
+
+    def log_prob_posterior_samples(
+        self,
+        theta: Token,
+        context: Token,
+    ) -> Array  # shape (batch_size,)
+```
+
+**Key Methods:**
+- `sample_posterior()`: Solves forward ODE to generate posterior samples
+  - Calls base distribution sampler to get x₀
+  - Solves ODE(t=0→1) with vf_network as vector field
+  - Returns final state as Token with structure metadata
+
+- `log_prob_posterior_samples()`: Computes log probs via FFJORD
+  - Solves augmented backward ODE(t=1→0) with trace estimation
+  - Accumulates log determinant of Jacobian
+  - Returns shape (batch_size,) log probability array
+
+- `_vector_field_wrapper()`: Adapts vector field for ODE solving
+  - Handles time parameter and vector field network interface
+  - Manages Token ↔ flattened array conversions
+
+**Dependencies:** ODE helpers, Token structures, base distribution, vector field network
+
+**Reuses:** FFJORD algorithm from sfmpe_legacy, flow matching concepts
+
+### Component 3: Training Loops (`tfmpe/estimators/training.py`)
+
+**Purpose:** Implement fast and memory-efficient training pipelines with CFM loss.
+
+#### fit_fast() - Speed-Optimized Training
+**Signature:**
+```python
+def fit_fast(
+    tfmpe: TFMPE,
+    train_tokens: Token,
+    val_tokens: Token,
+    optimizer: optax.GradientTransformation,
+    n_iter: int,
+    rng: PRNGKeyArray,
+) -> Tuple[TFMPE, Array]  # returns (trained_tfmpe, losses)
+```
+
+**Implementation:**
+- Reshape tokens to (n_batches, batch_size, ...)
+- Use nnx.scan over iterations for JIT compilation
+- Jittable loss function with vmap over batch samples
+- Weighted loss aggregation: loss × (batch_size / total_size)
+- Returns losses shape (n_iter, 2) with [train_loss, val_loss]
+
+**Key Properties:**
+- **Fully jittable** with `jax.jit()` via nnx.scan
+- No Python control flow in inner loop
+- Pre-computed batch indices for determinism
+
+#### fit_memory_efficient() - Memory-Optimized Training
+**Signature:**
+```python
+def fit_memory_efficient(
+    tfmpe: TFMPE,
+    token_generator: TokenGenerator,
+    val_tokens: Token,
+    optimizer: optax.GradientTransformation,
+    n_iter: int,
+    rng: PRNGKeyArray,
+    early_stopping_patience: int = 10,
+) -> Tuple[TFMPE, Array]  # returns (trained_tfmpe, losses)
+```
+
+**Implementation:**
+- Python loop iterates over token_generator batches
+- Gradient steps computed per batch
+- Early stopping with validation monitoring
+- Same CFM loss as fit_fast
+
+**Key Properties:**
+- Avoids materializing full dataset
+- Supports variable batch sizes from generator
+- Flexible early stopping criteria
+
+#### CFM Loss Function
+**Signature:**
+```python
+def cfm_loss(
+    tfmpe: TFMPE,
+    theta: Array,  # flattened parameters
+    context: Array,  # observations/context
+    theta_time: Array,  # uniform sample [0, 1]
+    rng: PRNGKeyArray,
+) -> Scalar
+```
+
+**Implementation:**
+1. Linear interpolation: σ_t = 1 - (1 - σ_min) × t
+2. Interpolated sample: θ_t = θ × σ_t + ε (ε ~ N(0,1))
+3. Target velocity: u_t = (θ - (1 - σ_min) × θ_t) / (1 - σ_t)
+4. Vector field prediction: v = vf_network(θ_t, context, t)
+5. MSE loss: mean((v - u_t)²), weighted by padding masks
+
+**Dependencies:** Vector field network, masking utilities
+
+**Reuses:** CFM loss from sfmpe_legacy/sfmpe/sfmpe.py
+
+## Data Models
+
+### Token Structure (Used Throughout)
+```python
+Token:
+  data: Array  # shape (n_samples, d_flat) - flattened parameters
+  labels: Array  # shape (n_samples, d_flat) - token labels for attention
+  masks: Optional[Array]  # shape (n_samples, d_flat) - padding masks
+  slices: SliceInfo  # metadata for unflattening
+  independence: Independence  # attention masking configuration
+```
+
+### ODE State
+```python
+# Forward: Array shape (d_flat,)
+# Backward: Array shape (d_flat,)
+# Augmented: Tuple[Array, Scalar] = (x, log_det_jacobian)
+```
+
+## Error Handling
+
+### Error Scenarios
+
+1. **Invalid ODE solver parameters**
+   - **Handling:** Validate rtol, atol > 0 in __init__
+   - **User Impact:** Raises ValueError at TFMPE initialization
+
+2. **Vector field network output shape mismatch**
+   - **Handling:** Assert vf_network output matches input shape
+   - **User Impact:** Raises AssertionError during first forward pass
+
+3. **NaN/Inf in ODE solving**
+   - **Handling:** odeint raises NumericalError, caught in training
+   - **User Impact:** Training iteration fails; user adjusts ODE parameters or learning rate
+
+4. **Mismatched Token shapes in training**
+   - **Handling:** Validate train/val tokens have same structure
+   - **User Impact:** Raises AssertionError at fit_fast() start
+
+5. **Generator exhaustion (fit_memory_efficient)**
+   - **Handling:** Break loop when generator yields no more batches
+   - **User Impact:** Training completes naturally
+
+## Testing Strategy
+
+### Unit Testing (test/estimators/test_ode.py)
+- **Doubling continuous flow**: f(θ) = log(2)·θ transforms N(0,1) → N(0,4)
+- **Forward ODE**: Verify trajectory matches analytical solutions
+- **Backward ODE**: Verify log_det_jacobian accumulation
+- **Batch operations**: Verify vmap correctness across sample batches
+
+### Integration Testing (test/estimators/test_tfmpe.py)
+- **Sampling consistency**: Verify samples from posterior distribution
+- **Log probability accuracy**: Check rtol=0.1, atol=0.5 stochastic tolerance
+- **Token compatibility**: Verify Token I/O with structured data
+- **End-to-end flow**: Train on synthetic data, verify sampling produces reasonable posterior
+
+### End-to-End Testing (test/estimators/test_e2e.py)
+- **Hierarchical Gaussian linear model**:
+  - σ ~ HalfNormal(1), μ ~ Normal(0, 1), y ~ Normal(μ, σ)
+  - Train TFMPE to learn posterior p(σ, μ | y)
+  - Verify loss decreases during training
+  - Verify posterior samples have reasonable statistics
+  - Verify log probabilities are finite and reasonable
+
+### Performance Benchmarks (test/benchmark/test_estimator_benchmark.py)
+- **Speed benchmark**: Training iteration time on standard hierarchical dataset
+- **Scale benchmark**: Training iteration time on large dataset (100k+ samples)
+- **Sampling speed**: Batch sampling throughput for different batch sizes
+- **Log prob speed**: Log probability computation throughput

--- a/.claude/specs/estimator/requirements.md
+++ b/.claude/specs/estimator/requirements.md
@@ -1,0 +1,138 @@
+# Requirements Document: Tokenized Flow Matching Estimator (TFMPE)
+
+## Introduction
+
+The TFMPE (Tokenized Flow Matching for Posterior Estimation) is a unified estimator class that combines sampling and log probability computation for flow matching-based posterior estimation. This consolidates the functionality previously split between `StructuredCNF` and `SFMPE` in the legacy codebase, integrating seamlessly with the new Token-based preprocessing system.
+
+## Alignment with Package Vision
+
+This feature directly supports the package's core goals:
+- **TFMPE**: The primary estimator for structured parameter inference problems
+- **Sample Efficiency**: Leverages flow matching with continuous normalizing flows for efficient posterior estimation
+- **Speed & Scalability**: Combined ODE solving infrastructure and tokenized training loops enable fast, memory-efficient training on hierarchical models
+
+## Requirements
+
+### Requirement 1: ODE Solving Infrastructure
+
+**User Story:** As a researcher, I want helper functions for setting up and solving ODEs for flow matching, so that I can efficiently compute sampling trajectories and log probabilities without worrying about low-level ODE mechanics.
+
+#### Acceptance Criteria
+
+1. WHEN solving forward ODE (t=0 to t=1) for sampling THEN SHALL efficiently compute trajectory using `jax.experimental.ode.odeint` with configurable tolerances
+2. WHEN solving backward ODE (t=1 to t=0) for log probability THEN SHALL use augmented state with trace estimation for FFJORD computation
+3. WHEN computing trajectories THEN SHALL handle both single samples and batches via vmap
+4. WHEN solving ODEs THEN SHALL accept vector field function, initial state, time points, and ODE solver parameters
+
+### Requirement 2: TFMPE Core Class for Sampling and Log Probability
+
+**User Story:** As a researcher, I want a unified TFMPE class that handles both sampling from the posterior and computing log probabilities, so that I have a single interface for inference without worrying about whether I'm using CNF or SFMPE semantics.
+
+#### Acceptance Criteria
+
+1. WHEN calling `sample_posterior()` THEN SHALL return posterior samples by solving forward ODE from base distribution
+2. WHEN calling `log_prob_posterior_samples()` THEN SHALL compute log probabilities for provided samples using backward ODE with trace estimation
+3. WHEN initializing TFMPE THEN SHALL accept trained vector field network and base distribution specification
+4. WHEN sampling THEN SHALL support batch sampling with configurable number of samples
+5. WHEN initializing TFMPE THEN SHALL accept a vector field network compatible with Token inputs (structured labels, indices, masks)
+
+### Requirement 3: Integration with Token-Based Preprocessing
+
+**User Story:** As a researcher, I want TFMPE to work seamlessly with the Token-based preprocessing system, so that I can handle structured parameters without manual flattening/unflattening logic.
+
+#### Acceptance Criteria
+
+1. WHEN TFMPE receives data THEN SHALL work with Token objects containing flattened arrays, labels, masks, and independence specifications
+2. WHEN sampling THEN SHALL return samples in Token format with appropriate structure metadata
+3. WHEN computing log probabilities THEN SHALL accept Token-formatted posterior samples
+
+### Requirement 4: ODE Helper Unit Tests
+
+**User Story:** As a developer, I want thorough unit tests for ODE solving helpers, so that I can verify correctness before building higher-level TFMPE functionality.
+
+#### Acceptance Criteria
+
+1. WHEN running doubling continuous flow test (f(θ) = log(2)·θ) THEN SHALL verify that N(0,1) transforms to N(0,4) within tolerance
+2. WHEN testing forward ODE THEN SHALL verify trajectory computation with analytical solutions
+3. WHEN testing backward ODE THEN SHALL verify trace-based log probability computation with stochastic tolerance
+4. WHEN testing batch operations THEN SHALL verify vmap correctness across sample batches
+
+### Requirement 5: TFMPE Integration and Functional Tests
+
+**User Story:** As a developer, I want integration tests for TFMPE's sampling and log probability methods, so that I can verify end-to-end functionality before implementing training loops.
+
+#### Acceptance Criteria
+
+1. WHEN training TFMPE on synthetic hierarchical data (θ ~ N(0,1), y ~ N(θ, σ²)) THEN SHALL recover base distribution via backward sampling
+2. WHEN testing TFMPE THEN SHALL verify log probability computations are accurate within stochastic tolerance (rtol=0.1, atol=0.5)
+3. WHEN sampling from posterior THEN SHALL verify consistency between forward ODE sampling and base distribution
+4. WHEN training TFMPE THEN SHALL handle structured inputs with labels, masks, and independence specifications
+
+### Requirement 6: Speed-Optimized Training Loop
+
+**User Story:** As a researcher, I want a fast training loop for TFMPE, so that I can quickly iterate on model designs and configurations.
+
+#### Acceptance Criteria
+
+1. WHEN training with `fit_fast()` THEN SHALL use nnx.scan-based training without Python loop overhead
+2. WHEN training THEN SHALL support batched loss computation with weighted aggregation (loss × batch_size / total_size)
+3. WHEN training THEN SHALL accept validation data and compute validation loss
+4. WHEN training THEN SHALL return loss history shape (n_iter, 2) with [train_loss, val_loss]
+5. WHEN training THEN SHALL implement Continuous Flow Matching (CFM) loss with linear interpolation between base and data distributions
+6. WHEN compiling `fit_fast()` THEN SHALL be fully jittable with `jax.jit()` for performance
+
+### Requirement 7: Memory-Efficient Training Loop with TokenGenerator
+
+**User Story:** As a researcher, I want a memory-efficient training loop for TFMPE on large datasets, so that I can scale to hierarchical problems without memory constraints.
+
+#### Acceptance Criteria
+
+1. WHEN training with `fit_memory_efficient()` THEN SHALL accept TokenGenerator for on-the-fly batch generation
+2. WHEN training THEN SHALL avoid materializing entire dataset in memory
+3. WHEN training THEN SHALL yield Token batches from generator during iteration
+4. WHEN training THEN SHALL support early stopping with validation monitoring
+5. WHEN training THEN SHALL implement same CFM loss and loss tracking as speed-optimized loop
+
+### Requirement 8: End-to-End Training Test
+
+**User Story:** As a developer, I want an E2E test that trains TFMPE on a realistic hierarchical model, so that I can verify the complete training pipeline works correctly.
+
+#### Acceptance Criteria
+
+1. WHEN running E2E test THEN SHALL train TFMPE on hierarchical Gaussian linear model with:
+   - σ ~ HalfNormal(1) [global parameter]
+   - μᵢ ~ Normal(0, 1) for each i [local parameters]
+   - yᵢⱼ ~ Normal(μᵢ, σ) for each observation j [observations]
+2. WHEN training THEN SHALL verify convergence through loss decrease
+3. WHEN testing THEN SHALL verify that trained estimator produces valid samples and log probabilities
+4. WHEN testing THEN SHALL complete within reasonable time (< 60 seconds)
+
+### Requirement 9: Performance Benchmarks
+
+**User Story:** As a developer, I want benchmarks for TFMPE training and inference, so that I can track performance regressions and verify scalability.
+
+#### Acceptance Criteria
+
+1. WHEN running speed benchmark THEN SHALL measure training loop iteration time on standard dataset
+2. WHEN running scale benchmark THEN SHALL measure training loop iteration time on large hierarchical dataset
+3. WHEN running benchmarks THEN SHALL measure sampling speed for different batch sizes
+4. WHEN benchmarking THEN SHALL measure log probability computation speed
+
+## Non-Functional Requirements
+
+### Performance
+- ODE solving must complete in < 1 second per sample for typical problems
+- Speed-optimized training loop must be 3-5x faster than Python loop equivalent
+- Log probability computation must use stochastic FFJORD with acceptable variance (rtol=0.1, atol=0.5)
+- Memory-efficient training must support datasets with > 100k samples without OOM
+
+### Maintainability
+- Code must follow project structure conventions (tfmpe/estimators/ for core, test/ for tests)
+- Type annotations required via jaxtyping (Array, PRNGKeyArray, etc.)
+- Line length ≤ 80 characters per project guidelines
+- Helper functions extracted for long/complex implementations
+
+### Compatibility
+- Must integrate with existing Token preprocessing system (tfmpe/preprocessing/)
+- Must work with transformer-based vector field networks in tfmpe/nn/transformer
+- Must follow JAX/Flax patterns established in legacy code

--- a/.claude/specs/estimator/tasks.md
+++ b/.claude/specs/estimator/tasks.md
@@ -1,0 +1,300 @@
+# Implementation Plan: Tokenized Flow Matching Estimator (TFMPE)
+
+## Task Overview
+
+Implementation follows a three-phase approach:
+1. **ODE Infrastructure** (Tasks 1-3): Build and test ODE solving helpers with doubling flow test
+2. **TFMPE Core & Integration** (Tasks 4-6): Implement TFMPE class with sampling/log_prob, integration tests
+3. **Training & Benchmarks** (Tasks 7-10): Implement fit_fast, fit_memory_efficient, E2E test, benchmarks
+
+## Steering Document Compliance
+
+All tasks follow structure.md conventions:
+- Source in `tfmpe/estimators/` with utilities in `ode.py`, `tfmpe.py`, `training.py`
+- Tests mirror structure in `test/estimators/`
+- Type annotations via jaxtyping (Array, PRNGKeyArray, Scalar)
+- Line length ≤ 80 characters, helper functions for complex logic
+- Benchmarks in `test/benchmark/`
+
+## Atomic Task Requirements
+
+**Each task meets these criteria:**
+- **File Scope**: Touches 1-3 related files maximum
+- **Time Boxing**: Completable in 15-30 minutes by experienced developer
+- **Single Purpose**: One testable outcome per task
+- **Specific Files**: Exact file paths specified
+- **Agent-Friendly**: Clear input/output with minimal context switching
+
+---
+
+## Tasks
+
+### Phase 1: ODE Infrastructure
+
+- [x] 1. Create ODE solver module structure and Diffrax solver wrapper
+  - Files: `tfmpe/estimators/ode.py`, `tfmpe/estimators/__init__.py`
+  - Implement `solve_forward_ode()` using Diffrax Dopri5 solver
+    - Parameters: vf_fn (callable), x0 (Array), solver, time_span, rtol, atol
+    - Returns: final state Array shape (*x0.shape)
+    - Use diffrax.diffeqsolve with vector_field argument
+  - Implement helper `_prepare_diffrax_vf()` to wrap vector field for Diffrax API
+    - Handles time parameter ordering (Diffrax expects t as first arg)
+  - Add exports to `tfmpe/estimators/__init__.py`
+  - Purpose: Foundation for ODE-based sampling
+  - _Leverage: sfmpe_legacy/sfmpe/structured_cnf.py for algorithm structure (adapted for Diffrax)_
+  - _Requirements: 1.1_
+
+- [x] 2. Implement backward ODE and augmented ODE solvers
+  - Files: `tfmpe/estimators/ode.py`
+  - Implement `solve_backward_ode()` for log probability computation
+    - Reverse time direction via negated vf_fn
+    - Parameters: vf_fn (callable), x1 (Array), solver, time_span, rtol, atol
+    - Returns: final state Array
+  - Implement `solve_augmented_ode()` with trace-based log determinant
+    - Augmented state: [x, log_det_jacobian]
+    - Trace computation via vjp method (vector-Jacobian products)
+    - Parameters: vf_fn (callable), x0 (Array), solver, time_span, rtol, atol
+    - Returns: Tuple[Array, Scalar] = (final_x, final_log_det_jacobian)
+  - Implement helper `_augmented_ode_fn()` that handles augmented state dynamics
+  - Purpose: Log probability computation via FFJORD algorithm
+  - _Leverage: FFJORD trace estimation from sfmpe_legacy/sfmpe/structured_cnf.py_
+  - _Requirements: 1.1, 1.2_
+
+- [x] 3. Implement batched ODE solver with vmap
+  - Files: `tfmpe/estimators/ode.py`
+  - Implement `batch_solve_forward_ode()` for efficient batch sampling
+    - Signature: vf_fn, x0_batch (Array shape (batch, *state_shape)), solver, time_span, rtol, atol
+    - Returns: Array shape (batch, *state_shape)
+    - Use jax.vmap over first axis to parallelize across samples
+    - Vectorized vf_fn application per sample
+  - Implement `batch_solve_augmented_ode()` for batched log prob
+    - Signature: vf_fn, x0_batch, solver, time_span, rtol, atol
+    - Returns: Tuple[Array shape (batch, *state_shape), Array shape (batch,)]
+  - Purpose: Enable efficient batch operations for sampling/log prob
+  - _Requirements: 1.1, 1.2_
+
+- [x] 4. Create doubling continuous flow unit test
+  - Files: `test/estimators/test_ode.py`
+  - Test `solve_forward_ode()` with doubling flow vector field
+    - Vector field: f(θ) = log(2) · θ (exponential scaling)
+    - Initial: θ₀ ~ N(0, 1)
+    - Final: θ₁ should follow N(0, 4) analytically
+    - Verify mean ≈ 0, std ≈ 2 with rtol=0.1
+    - Sample 1000 trajectories, check statistics
+  - Test `solve_backward_ode()` reverses forward trajectory
+    - Verify backward(forward(x)) ≈ x within tolerance
+  - Purpose: Verify correctness of forward/backward ODE solving
+  - _Leverage: test patterns from sfmpe_legacy/test/test_cnf_density.py_
+  - _Requirements: 1.1, 1.2, 4.1, 4.2, 4.3, 4.4_
+
+- [x] 5. Create unit tests for augmented ODE and batch operations
+  - Files: `test/estimators/test_ode.py` (continue from 4)
+  - Test `solve_augmented_ode()` trace computation
+    - Compare trace estimate vs analytical jacobian for simple linear vf
+    - Linear vf: f(x) = A·x (matrix A) should have log_det ≈ log|det(A)|
+    - Test with 2x2 and 5x5 matrices
+  - Test batch operations: `batch_solve_forward_ode()`, `batch_solve_augmented_ode()`
+    - Verify vmap gives same results as loop over samples
+    - Verify batch shapes correct: (batch_size, *state_shape)
+  - Purpose: Ensure batch operations and trace computation work correctly
+  - _Requirements: 1.1, 1.2, 1.3, 4.1, 4.3_
+
+---
+
+### Phase 2: TFMPE Core & Integration
+
+- [x] 6. Create TFMPE core class with initialization
+  - Files: `tfmpe/estimators/tfmpe.py`
+  - Implement `TFMPE` class with initialization
+    - Parameters:
+      - `vf_network`: Callable or nnx.Module for vector field (Token → Array → Array)
+      - `base_dist_fn`: Callable(rng, shape) → Array for base distribution sampling
+      - `base_log_prob_fn`: Callable(x) → scalar for log probability of base
+      - `solver`: Diffrax solver instance (default: Heun())
+      - `ode_kwargs`: dict with rtol, atol defaults (default: rtol=1e-5, atol=1e-5)
+    - Store as instance attributes
+  - Implement type annotations using jaxtyping (Array, PRNGKeyArray, Scalar)
+  - Add docstrings with numpy-style format
+  - Purpose: Foundation for TFMPE interface
+  - _Leverage: SFMPE class structure from sfmpe_legacy/sfmpe/sfmpe.py_
+  - _Requirements: 2.1, 2.2, 2.3, 2.4_
+
+- [x] 7. Implement TFMPE sampling method
+  - Files: `tfmpe/estimators/tfmpe.py`
+  - Implement `sample_posterior()` method
+    - Signature: context (Token), params (Token), rng (PRNGKeyArray) → Token
+    - Fills params.data with base_dist_fn samples
+    - Calls solve_forward_ode() with vector field and params
+    - Returns sampled Token with structure metadata preserved
+  - Purpose: Generate posterior samples via ODE solving
+  - _Leverage: sample() method from sfmpe_legacy/sfmpe/structured_cnf.py_
+  - _Requirements: 2.1, 3.1, 3.2_
+
+- [x] 8. Implement TFMPE log probability method
+  - Files: `tfmpe/estimators/tfmpe.py`
+  - Implement `log_prob_posterior_samples()` method
+    - Signature: theta (Token), context (Token) → Array (scalar)
+    - Computes base log prob via base_log_prob_fn(theta.data)
+    - Calls solve_augmented_ode() to get trace-based log determinant
+    - Returns log_prob_base + log_det_jacobian
+  - Optional `n_epsilon` parameter for FFJORD trace samples (default: 10)
+  - Purpose: Compute log probabilities for FFJORD algorithm
+  - _Leverage: log_prob() method from sfmpe_legacy/sfmpe/structured_cnf.py_
+  - _Requirements: 2.1, 2.2, 2.3, 5.2, 5.3_
+
+- [x] 9. Create TFMPE integration tests
+  - Files: `test/estimators/test_tfmpe.py`
+  - Test `sample_posterior()` with synthetic data
+    - Create simple context Token
+    - Call sample_posterior() for 100 samples
+    - Verify output Token shape and structure
+    - Verify samples are finite, no NaNs/Infs
+  - Test `log_prob_posterior_samples()`
+    - Compute log_prob for known distribution
+    - Compare to analytical log_prob within stochastic tolerance (rtol=0.1, atol=0.5)
+    - Test with simple Gaussian posterior
+  - Test Token format preservation
+    - Verify sampled Token has same labels, masks as context
+    - Verify slices metadata preserved
+  - Test consistency: log_prob(samples from posterior)
+    - Verify log probabilities are finite and reasonable
+  - Purpose: Verify TFMPE sampling and log_prob work correctly with Token data
+  - _Leverage: Integration test patterns from sfmpe_legacy/test/_
+  - _Requirements: 3.1, 3.2, 5.1, 5.2, 5.3, 5.4_
+
+---
+
+### Phase 3: Training & Benchmarks
+
+- [ ] 10. Implement CFM loss function
+  - Files: `tfmpe/estimators/training.py`
+  - Implement `cfm_loss()` function
+    - Signature: tfmpe (TFMPE), theta (Array), context (Array), time (Scalar), rng (PRNGKeyArray) → Scalar
+    - Parameters:
+      - theta: flattened parameters Array (batch, d_flat)
+      - context: flattened observations Array (batch, d_obs)
+      - time: uniform sample from [0, 1] Shape ()
+      - rng: PRNG key for noise sampling
+    - Algorithm:
+      1. Compute σ_t = 1 - (1 - σ_min) × t where σ_min = 1e-4
+      2. Sample ε ~ N(0, I) with same shape as theta
+      3. Interpolate: θ_t = θ × σ_t + ε × sqrt(1 - σ_t²)
+      4. Compute target velocity: u_t = (θ - (1 - σ_min) × θ_t) / (1 - σ_t)
+      5. Predict velocity: v = vf_network(θ_t, context, t)
+      6. Compute MSE: mean((v - u_t)²)
+    - Handle masking: apply padding masks if provided
+    - Return scalar loss
+  - Purpose: Core training loss for flow matching
+  - _Leverage: _cfm_loss from sfmpe_legacy/sfmpe/sfmpe.py_
+  - _Requirements: 6.5_
+
+- [x] 11. Implement fit_fast() speed-optimized training loop
+  - Files: `tfmpe/estimators/training.py`
+  - Implement `fit_fast()` function
+    - Signature: tfmpe (TFMPE), train_tokens (Token), val_tokens (Token), opt (nnx.Optimizer), n_iter (int), rng (PRNGKeyArray) → Tuple[TFMPE, Array]
+    - Implementation:
+      1. Extract flattened arrays from Tokens
+      2. Reshape to (n_batches, batch_size, d_flat)
+      3. Create loss_fn that vmaps cfm_loss over batch samples
+      4. Implement gradient_step() that applies optimizer.update()
+      5. Use nnx.scan to scan over iterations
+      6. Compute weighted loss: loss × (batch_size / total_size)
+      7. Compute validation loss on full val set
+      8. Return (trained_tfmpe, losses) shape (n_iter, 2)
+  - **Critical**: Implementation must be fully jittable with jax.jit()
+    - No Python control flow in scanned loop
+    - All randomness via PRNG keys (key_split per iteration)
+    - Pre-compute batch indices
+    - Pass nnx.Optimizer as argument to avoid unhashable optax callables in JIT
+    - Mark n_iter as static_argnames when JITing
+  - Purpose: Fast training via JIT compilation
+  - _Leverage: fit_model_no_branch from sfmpe_legacy/sfmpe/train.py_
+  - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.5, 6.6_
+
+- [ ] 12. Implement fit_memory_efficient() training loop
+  - Files: `tfmpe/estimators/training.py`
+  - Implement `fit_memory_efficient()` function
+    - Signature: tfmpe (TFMPE), token_gen (TokenGenerator), val_tokens (Token), optimizer (optax.GradientTransformation), n_iter (int), rng (PRNGKeyArray), early_stopping_patience (int) → Tuple[TFMPE, Array]
+    - Implementation:
+      1. Python loop over iterations
+      2. For each iteration, get batch from token_gen
+      3. Extract flattened arrays, vmap cfm_loss over batch
+      4. Compute gradient, apply optimizer.update()
+      5. Accumulate weighted loss
+      6. Every K iterations: compute validation loss
+      7. Early stopping: stop if val loss doesn't improve for patience iterations
+      8. Return (trained_tfmpe, losses) - losses shape (actual_iters, 2)
+    - Support variable batch sizes from generator
+    - Collect losses in list, convert to array at end
+  - Purpose: Memory-efficient training on large datasets
+  - _Requirements: 7.1, 7.2, 7.3, 7.4, 7.5_
+
+- [x] 13. Create end-to-end training test
+  - Files: `test/estimators/test_e2e_training.py`
+  - Generate hierarchical Gaussian linear model data
+    - Parameters: σ ~ HalfNormal(1), μᵢ ~ Normal(0, 1), yᵢⱼ ~ Normal(μᵢ, σ)
+    - Generate N_groups=10 groups, N_obs=20 observations per group
+    - Flatten to Token format with labels for structure
+  - Create TFMPE with simple transformer vector field
+  - Test fit_fast() training
+    - Train for 50 iterations with batch_size=5
+    - Verify training loss decreases
+    - Verify final model produces valid samples and log_probs
+    - Check execution time < 60 seconds
+  - Test fit_memory_efficient() training
+    - Create TokenGenerator for streaming batches
+    - Train for 50 iterations with batch_size=5
+    - Verify training loss decreases
+    - Verify early stopping works (patience=5)
+  - Purpose: Verify complete training pipeline on realistic problem
+  - _Leverage: E2E test patterns from sfmpe_legacy/test/_
+  - _Requirements: 8.1, 8.2, 8.3, 8.4_
+
+- [ ] 14. Create performance benchmarks
+  - Files: `test/benchmark/test_estimator_benchmark.py`
+  - Implement speed benchmark (standard dataset)
+    - Hierarchical Gaussian data: N_groups=50, N_obs=10
+    - Measure fit_fast() training iteration time (20 iterations)
+    - Benchmark name: "tfmpe_fit_fast_speed"
+    - Mark with @pytest.mark.benchmark(group="speed")
+  - Implement scale benchmark (large dataset)
+    - Hierarchical Gaussian data: N_groups=500, N_obs=20
+    - Measure fit_fast() training iteration time (10 iterations)
+    - Benchmark name: "tfmpe_fit_fast_scale"
+    - Mark with @pytest.mark.benchmark(group="scale")
+  - Implement sampling benchmark
+    - Measure batch_solve_forward_ode() for 100, 1000, 10000 samples
+    - Benchmark different batch sizes
+  - Implement log_prob benchmark
+    - Measure batch_solve_augmented_ode() for 100, 1000, 10000 samples
+  - Purpose: Track performance regressions and verify scalability
+  - _Requirements: 9.1, 9.2, 9.3, 9.4_
+
+---
+
+## Implementation Notes
+
+### Jittability for fit_fast()
+- Use nnx.scan for iteration loop (enables JAX JIT)
+- Pre-compute epoch/batch indices arrays
+- Split PRNG keys deterministically: `jax.random.fold_in(key, iter)`
+- Reshape training data outside jit (or pre-reshape as constant)
+- Return scalar loss values only
+
+### Token Integration
+- Token: container with `data`, `labels`, `masks`, `slices`, `independence`
+- Use `Token.data` for flattened arrays in ODE solvers
+- Use `Token.slices` to unflatten samples back to structured format
+- Preserve Token metadata (labels, masks) in sampled output
+
+### Diffrax API
+- Solver: `diffrax.Heun()` (default) or configurable
+- `diffrax.diffeqsolve(vf, solver, t0, t1, dt0, y0, args=...)`
+- TimeKeeper: `diffrax.SaveAt(ts=times)` for trajectory saving
+- For final state only: use `t0, t1` without SaveAt
+
+### Testing Patterns
+- Use pytest for all tests
+- Mark slow tests with `@pytest.mark.slow`
+- Use `numpy.testing.assert_allclose()` for numerical comparisons
+- Use custom PRNG keys per test: `jax.random.PRNGKey(seed)`

--- a/.claude/specs/labeller/design.md
+++ b/.claude/specs/labeller/design.md
@@ -1,0 +1,211 @@
+# Design Document: Labeller Refactoring
+
+## Overview
+
+This design introduces a new `Labeller` type that decouples label generation logic from the `Tokens` class. Currently, `Tokens` stores `label_map` (key → integer mapping) and `key_order` (ordered key list) to handle label array generation. With this refactoring, `Labeller` will store only `label_map` (more DRY, no key duplication), while `Tokens` removes both fields since key order can be derived from `slices` dictionary ordering via a `key_order` property.
+
+The refactoring also relaxes the constraint in `combine_tokens()` that previously required identical `key_order` across both input tokens, enabling more flexible token combination workflows.
+
+## Steering Document Alignment
+
+### Technical Standards (tech.md)
+- **Functions over Classes**: `Labeller` is a dataclass (function-like composition) not a class with inheritance
+- **Type Annotations**: Full jaxtyping support with `Array` type for label outputs
+- **JAX Integration**: Maintains JAX PyTree registration if needed for gradient tracking
+- **Testing**: pytest-based unit testing with clear test naming
+
+### Project Structure (structure.md)
+- **Location**: `Labeller` defined in `tfmpe/preprocessing/utils.py` alongside `Independence` and `SliceInfo`
+- **Import Pattern**: Named imports at top of file, following project conventions
+- **Test Location**: Unit tests in `test/test_preprocessing/test_labeller.py` (new file)
+
+## Code Reuse Analysis
+
+### Existing Components to Leverage
+- **SliceInfo NamedTuple**: Already used in `Tokens` to describe token metadata (offset, event_shape, batch_shape)
+- **Existing label generation logic**: Current `Tokens.from_pytree()` implementation shows label array creation pattern that `Labeller.label()` will replicate
+- **Independence type**: Already decouples independence logic from Tokens; `Labeller` follows same pattern for labels
+- **JAX utilities**: Use `jnp.full()`, `jnp.concatenate()`, `jnp.broadcast_to()` for label array construction
+
+### Integration Points
+- **Tokens class**: Remove `label_map` field, modify `from_pytree()` to accept `Labeller` instance
+- **combine_tokens()**: Refactor to work with different key_order by computing union of keys
+- **Transformer embedding**: Use `Labeller` instance to generate labels instead of extracting from `Tokens`
+- **Tests**: Update fixtures and test code that previously relied on `select_tokens()`
+
+## Architecture
+
+```mermaid
+graph TD
+    A["PyTree Dict"] -->|from_pytree| B["Tokens"]
+    A -->|keys| C["Labeller"]
+    C -->|label method| D["Label Array"]
+    B -->|uses| D
+    E["Transformer"] -->|forward pass| B
+    E -->|uses| C
+    B -->|combine_tokens| F["Combined Tokens"]
+```
+
+## Components and Interfaces
+
+### Component 1: Labeller Type
+
+- **Purpose**: Store global label mappings for a set of keys; provide label array generation across token instances
+- **Location**: `tfmpe/preprocessing/utils.py`
+- **Interfaces**:
+  - `__init__(label_map: Dict[str, int])` - Initialize with key-to-label mapping
+  - `.label_map` field - Returns `Dict[str, int]` mapping key names to indices
+  - `.label(slices: Dict[str, SliceInfo]) -> Array` - Generate label array (no broadcasting needed)
+
+- **Dependencies**:
+  - `SliceInfo` from same module
+  - `jax.numpy` for array operations
+  - `jaxtyping.Array` for type annotations
+
+- **Reuses**:
+  - Label generation pattern from `Tokens.from_pytree()` (lines 129-155 in tokens.py)
+  - `SliceInfo` structure already defined in utils.py
+
+### Component 2: Tokens Class (Modified)
+
+- **Purpose**: Container for structured token data (unchanged conceptually, only field removal)
+- **Removals**:
+  - Remove `label_map: Dict[str, int]` field (lines 62-63 in tokens.py)
+  - Remove `key_order: List[str]` field (lines 49-50 in tokens.py)
+  - Remove `label_map` construction from `from_pytree()` (line 129)
+  - Remove `key_order` construction from `from_pytree()` (line 126)
+  - Remove `label_map` and `key_order` from `with_values()` return (lines 442-443)
+  - Remove `label_map` and `key_order` from PyTree aux_data (lines 467-468)
+
+- **Additions**:
+  - Add `key_order` property that derives ordering from `slices.keys()` in slice offset order
+  - Update docstring to document new property
+
+- **Retained**:
+  - `slices: Dict[str, SliceInfo]` - contains all information needed to derive key order
+  - All other fields and methods unchanged
+
+- **Breaking Changes**:
+  - `select_tokens()` method removed entirely (lines 239-365)
+  - Code accessing `.key_order` must work with it as a computed property (same interface, different backing)
+  - Tests that assert on `label_map` will need updates
+  - Code creating `Tokens` directly must no longer pass `label_map` or `key_order`
+
+### Component 3: combine_tokens() Function (Refactored)
+
+- **Purpose**: Combine multiple Tokens with flexible key handling
+- **Location**: `tfmpe/preprocessing/combine.py`
+- **Current Constraint**: Line 47-51 requires `tokens1.key_order == tokens2.key_order`
+
+- **New Behavior**:
+  - Remove key_order equality check
+  - Compute union of all keys from both tokens
+  - For each key:
+    - If in both tokens: use max event_shape (current behavior)
+    - If in one token: use that token's slice info
+  - Stretch labels as necessary to match padded token dimensions
+  - Ensure padding mask correctly handles all keys
+
+- **Implementation Details**:
+  - Build set of all keys from both tokens
+  - Iterate over union (maintaining consistent ordering)
+  - Handle slices gracefully when key missing in one token
+
+## Data Models
+
+### Labeller
+```python
+@dataclass
+class Labeller:
+    """Global label information for a set of keys."""
+
+    label_map: Dict[str, int]  # Mapping from key names to integer label indices
+
+    def label(
+        self,
+        slices: Dict[str, SliceInfo]
+    ) -> Array:
+        """
+        Generate label array for given token configuration.
+
+        Parameters
+        ----------
+        slices : Dict[str, SliceInfo]
+            Token metadata mapping with keys in offset order
+
+        Returns
+        -------
+        Array
+            Label array with shape (n_total_tokens,)
+        """
+        # Build labels from slices using label_map
+        # Concatenate per-key label arrays in slice offset order
+```
+
+## Error Handling
+
+### Error Scenarios
+
+1. **Labeller with empty label_map**
+   - **Handling**: Raise ValueError("Labeller requires at least one key mapping")
+   - **User Impact**: Caught during Labeller initialization, clear error message
+
+2. **label() called with keys not in label_map**
+   - **Handling**: Raise KeyError with informative message about missing key
+   - **User Impact**: Clear error on label generation if key in slices not in label_map
+
+3. **combine_tokens() with incompatible slices**
+   - **Handling**: Keep existing validation (independence, functional_inputs)
+   - **User Impact**: Existing error handling unchanged
+
+
+## Testing Strategy
+
+### Unit Testing (Labeller)
+
+**File**: `test/test_preprocessing/test_labeller.py`
+
+Test cases:
+- `test_labeller_init_with_label_map` - Verify Labeller initialization
+- `test_labeller_label_single_key` - Label generation with one key
+- `test_labeller_label_multi_key` - Label generation with multiple keys
+- `test_labeller_label_with_different_event_shapes` - Various token shapes
+- `test_labeller_label_correct_indices` - Verify correct label indices per key
+- `test_labeller_label_correct_shapes` - Verify output shape matches total tokens
+- `test_labeller_label_consistency` - Same input → same output
+- `test_labeller_empty_map_raises` - Error handling for empty label_map
+- `test_labeller_missing_key_raises` - Error handling for key not in label_map
+
+### Integration Testing
+
+**Updates to**: `test/test_preprocessing/test_tokens_dynamic.py`
+
+Changes:
+- Replace `select_tokens()` tests with tests that create Tokens directly or use alternative filtering
+- Update tests asserting `key_order` and `label_map` values
+- Add tests for Labeller-aware label generation
+- Ensure labels still match token structure
+
+**Updates to**: `test/test_nn/test_transformer/test_transformer.py`
+
+Changes:
+- Update fixtures that used `select_tokens()`
+- Verify transformer still works with Labeller-generated labels
+- Test combining tokens in transformer workflows
+
+**Updates to**: Combine function tests (new test file or additions)
+
+Changes:
+- Add tests for `combine_tokens()` with different key_order
+- Verify label generation with union of keys
+- Test padding mask correctness with different keys
+
+## Migration Path
+
+1. **Phase 1**: Create `Labeller` type, add unit tests (no breaking changes yet)
+2. **Phase 2**: Update `Tokens` to use `Labeller`, remove `label_map`
+3. **Phase 3**: Remove `select_tokens()` method
+4. **Phase 4**: Refactor `combine_tokens()` for flexible key handling
+5. **Phase 5**: Update all integration tests and verify everything works
+
+This phased approach allows validation at each step before proceeding to breaking changes.

--- a/.claude/specs/labeller/requirements.md
+++ b/.claude/specs/labeller/requirements.md
@@ -1,0 +1,91 @@
+# Requirements Document: Labeller Refactoring
+
+## Introduction
+
+Currently, the `Tokens` class uses `select_tokens()` to create sliced token sets with selected keys. This method was originally designed to tie together different token instances with shared independence and label data. However, with the introduction of the `Independence` type, the purpose of `Tokens.select_tokens()` has become conceptually redundant—it's silly to create a global `Tokens` instance just to call `select_tokens()`.
+
+This refactoring introduces a new `Labeller` type that decouples global labelling information from token data. The `Labeller` stores only the label mapping (key → integer index) and provides a `.label()` method that generates label arrays from token slice information. This allows individual token instances to be created independently while maintaining consistent labeling through a shared `Labeller` instance. Additionally, `Tokens.key_order` will become a computed property derived from slices, eliminating redundant storage.
+
+## Alignment with Package Vision
+
+This refactoring supports the package goals of **maintainability** and **efficient data preprocessing**:
+- **Cleaner API**: Removes conceptual confusion by separating labelling concerns from token slicing
+- **Better separation of concerns**: `Labeller` handles labels, `Tokens` focuses on data representation
+- **More flexible token usage**: Tokens can be created and manipulated independently without requiring a global `Tokens` instance for labeling context
+- **DRY principle**: Eliminates duplicate key storage by keeping only `label_map` in `Labeller` and deriving `key_order` from `slices`
+- **Simplified `Tokens` class**: Reduces class complexity by removing redundant fields while maintaining backward compatibility via properties
+
+## Requirements
+
+### Requirement 1: Create Labeller Type
+
+**User Story:** As a developer, I want a `Labeller` type that stores global label mappings, so that any token instance can have consistent labels with others without needing a global `Tokens` instance.
+
+#### Acceptance Criteria
+
+1. WHEN a `Labeller` is instantiated with a label_map THEN it SHALL accept `Dict[str, int]` mapping key names to integer indices
+2. WHEN a `Labeller` has a `.label()` method called with slices THEN it SHALL return a 1D label array with integer labels for all keys in slice offset order
+3. WHEN different `Labeller` instances are created with the same label_map THEN they SHALL produce identical label arrays
+4. WHEN a `Labeller` is used with multiple `Tokens` instances THEN all instances SHALL share consistent label values across keys
+
+### Requirement 2: Unit Test Labeller
+
+**User Story:** As a developer, I want comprehensive unit tests for `Labeller`, so that I can verify its correctness and catch regressions.
+
+#### Acceptance Criteria
+
+1. WHEN testing `Labeller` initialization THEN unit tests SHALL verify label_map storage
+2. WHEN testing `.label()` method THEN unit tests SHALL verify label arrays have correct indices and shape (n_total_tokens,)
+3. WHEN testing `.label()` with different slice configurations THEN unit tests SHALL verify correct label generation for various event_shapes and key types
+4. WHEN testing `Labeller` with edge cases THEN unit tests SHALL cover single-key, multi-key scenarios and error conditions
+
+### Requirement 3: Remove select_tokens Method
+
+**User Story:** As a developer, I want `select_tokens()` removed from the `Tokens` class, so that token slicing logic is simplified and the API is cleaner.
+
+#### Acceptance Criteria
+
+1. WHEN `select_tokens()` is removed from `Tokens` THEN existing code paths that use it SHALL be updated to use alternative approaches
+2. WHEN existing integration tests use `select_tokens()` THEN they SHALL be refactored to directly create `Tokens` instances with selected keys or use alternative filtering mechanisms
+3. WHEN removing `select_tokens()` THEN the `Tokens.label_map` field SHALL be removed and `Tokens.key_order` SHALL become a computed property
+
+### Requirement 4: Relax combine_tokens Key Order Constraint
+
+**User Story:** As a developer, I want `combine_tokens()` to work with tokens that have different key_order, so that token combination is more flexible.
+
+#### Acceptance Criteria
+
+1. WHEN combining two `Tokens` instances with different key_order THEN `combine_tokens()` SHALL succeed instead of raising ValueError
+2. WHEN combining tokens with different keys THEN the result SHALL contain the union of all keys from both tokens
+3. WHEN a key appears in only one input token THEN the combined result SHALL use that token's slice info for that key
+4. WHEN combining tokens with overlapping keys THEN the result SHALL use max event_shape per key (existing behavior)
+
+### Requirement 5: Update Integration Tests
+
+**User Story:** As a developer, I want the refactored code integrated into all existing test suites, so that the new `Labeller` is validated end-to-end.
+
+#### Acceptance Criteria
+
+1. WHEN running existing integration tests in `test_tokens_dynamic.py` THEN all tests SHALL pass with refactored code
+2. WHEN running transformer integration tests in `test_transformer.py` THEN all tests SHALL pass with the new `Labeller` used for label generation
+3. WHEN a test previously used `select_tokens()` THEN the test SHALL be updated to construct tokens directly with selected keys or use alternative mechanisms
+
+## Non-Functional Requirements
+
+### Performance
+- Labeller initialization and `.label()` method calls SHALL complete in negligible time (no performance regression)
+- Label array generation SHALL use the same efficient JAX operations as current implementation
+- Computing `key_order` property from slices SHALL be efficient
+- `combine_tokens()` performance SHALL not degrade when handling different key orders
+
+### Usability
+- `Labeller` API SHALL be intuitive and follow existing naming conventions (consistent with `Tokens` and `Independence`)
+- `Labeller` SHALL be documented with docstrings explaining purpose and usage
+- Type annotations SHALL be comprehensive and include jaxtyping types
+- `Tokens.key_order` property SHALL maintain same interface as before (no code changes needed)
+
+### Maintainability
+- Removal of `label_map` and `key_order` fields from `Tokens` SHALL reduce class complexity
+- Code SHALL pass `pyright` type checking with no new issues
+- All tests SHALL pass including integration tests
+- `combine_tokens()` refactoring SHALL maintain readability and documentation

--- a/.claude/specs/labeller/tasks.md
+++ b/.claude/specs/labeller/tasks.md
@@ -1,0 +1,171 @@
+# Implementation Plan: Labeller Refactoring
+
+## Task Overview
+
+The implementation follows a phased approach to minimize breaking changes and allow validation at each step:
+1. Create and test `Labeller` type
+2. Integrate `Labeller` into `Tokens` and remove `label_map`
+3. Add `key_order` property to `Tokens` and remove field
+4. Remove `select_tokens()` method
+5. Refactor `combine_tokens()` for flexible key handling
+6. Update all integration tests
+
+## Steering Document Compliance
+
+All tasks follow `structure.md` conventions:
+- Test files mirror source file structure
+- Named imports at top, following standard order
+- Type annotations using jaxtyping
+- Functions over classes approach
+- JAX-based array operations
+
+## Atomic Task Requirements
+
+Each task is designed to:
+- Touch 1-3 related files maximum
+- Complete in 15-30 minutes
+- Have single testable outcome
+- Include specific file paths
+- Be clear for agent execution
+
+## Tasks
+
+- [x] 1. Create Labeller dataclass in tfmpe/preprocessing/utils.py
+  - File: `tfmpe/preprocessing/utils.py`
+  - Add `Labeller` dataclass with `label_map: Dict[str, int]` field
+  - Add docstring explaining purpose (stores global label mappings)
+  - Purpose: Define the Labeller type to store key-to-label mappings
+  - _Leverage: existing `SliceInfo` and `Independence` in same file_
+  - _Requirements: 1.1_
+
+- [x] 2. Implement Labeller.label() method in tfmpe/preprocessing/utils.py
+  - File: `tfmpe/preprocessing/utils.py` (continue from task 1)
+  - Implement `.label(slices: Dict[str, SliceInfo]) -> Array` method
+  - Iterate through slices in offset order, create per-key label arrays using label_map, concatenate
+  - Return 1D array of shape (n_total_tokens,) with label indices
+  - Add comprehensive docstring with parameter descriptions
+  - Purpose: Enable label array generation from Labeller
+  - _Leverage: label generation logic from `Tokens.from_pytree()` lines 129-155 in tokens.py_
+  - _Requirements: 1.2, 1.3_
+
+- [x] 3. Create unit tests for Labeller in test/test_preprocessing/test_labeller.py
+  - File: `test/test_preprocessing/test_labeller.py` (new file)
+  - Test Labeller initialization with label_map
+  - Test `.label()` with single and multiple keys
+  - Test `.label()` with different event_shapes
+  - Test label indices are correct per key and array shape
+  - Test label consistency across multiple calls
+  - Test error handling (empty label_map, missing keys in slices)
+  - Purpose: Comprehensive Labeller validation
+  - _Leverage: fixtures from conftest.py, test patterns from test_tokens_dynamic.py_
+  - _Requirements: 2.1, 2.2, 2.3, 2.4_
+
+- [x] 4. Add Labeller to preprocessing module exports in tfmpe/preprocessing/__init__.py
+  - File: `tfmpe/preprocessing/__init__.py`
+  - Add `Labeller` to imports from `utils`
+  - Add `Labeller` to `__all__` list
+  - Purpose: Make Labeller publicly available through preprocessing module
+  - _Leverage: existing module structure_
+  - _Requirements: 1.1_
+
+- [x] 5. Remove label_map field from Tokens dataclass in tfmpe/preprocessing/tokens.py
+  - File: `tfmpe/preprocessing/tokens.py`
+  - Remove `label_map: Dict[str, int]` field definition (line 62-63)
+  - Remove `label_map` construction from `from_pytree()` (line 129)
+  - Remove `label_map` from return statement in `from_pytree()` (line 179)
+  - Remove `label_map` from `with_values()` method (line 442)
+  - Remove `label_map` from PyTree aux_data in `tree_unflatten()` (line 467)
+  - Update docstrings to reflect field removal
+  - Purpose: Decouple label mapping from Tokens class
+  - _Leverage: existing Tokens structure_
+  - _Requirements: 3.1_
+
+- [x] 6. Add key_order property to Tokens class in tfmpe/preprocessing/tokens.py
+  - File: `tfmpe/preprocessing/tokens.py`
+  - Remove `key_order: List[str]` field definition (line 49-50)
+  - Remove `key_order` construction from `from_pytree()` (line 126)
+  - Remove `key_order` from return statement in `from_pytree()` (line 179)
+  - Remove `key_order` from `with_values()` method (line 443)
+  - Remove `key_order` from PyTree aux_data in `tree_unflatten()` (line 468)
+  - Add `@property` `key_order()` method that derives order from slices by sorting keys by slice offset
+  - Update docstrings to document new property
+  - Purpose: Eliminate redundant key_order storage while maintaining API compatibility
+  - _Leverage: existing slices structure_
+  - _Requirements: 3.1_
+
+- [x] 7. Remove select_tokens() method from Tokens class in tfmpe/preprocessing/tokens.py
+  - File: `tfmpe/preprocessing/tokens.py`
+  - Remove entire `select_tokens()` method (lines 239-365)
+  - Update Tokens docstring to remove mention of select_tokens
+  - Purpose: Simplify Tokens API by removing slicing method
+  - _Leverage: none (pure removal)_
+  - _Requirements: 3.2_
+
+- [x] 8. Update combine_tokens() to support different key_order in tfmpe/preprocessing/combine.py
+  - File: `tfmpe/preprocessing/combine.py`
+  - Remove key_order equality check (lines 47-51)
+  - Compute union of all keys from both tokens: `union_keys = list(dict.fromkeys(tokens1.key_order + tokens2.key_order))`
+  - Refactor max_event_shapes dict building to iterate over union_keys instead of tokens1.key_order
+  - For each key in union_keys:
+    - Get event_shape from whichever token has the key (or max if both have it)
+    - Use union_keys order when building new slices offsets
+  - Update _build_combined_labels() to work with union_keys
+  - Update _build_combined_padding_mask() to work with union_keys
+  - Update docstring to reflect new behavior (union of keys)
+  - Purpose: Enable combining tokens with different keys
+  - _Leverage: existing padding and masking logic, Tokens.key_order property_
+  - _Requirements: 4.1, 4.2, 4.3, 4.4_
+
+- [x] 9. Create integration tests for combine_tokens() with different keys in test/test_preprocessing/test_combine.py
+  - File: `test/test_preprocessing/test_combine.py` (add to existing if exists)
+  - Test combining tokens with identical key_order (existing behavior should still work)
+  - Test combining tokens with subset relationship (one token has keys that other doesn't)
+  - Test combining tokens with completely different keys
+  - Verify combined slices are correct, labels are correct, padding mask is correct
+  - Purpose: Validate flexible combine_tokens() behavior
+  - _Leverage: fixtures from conftest.py, token creation patterns_
+  - _Requirements: 4.1, 4.2, 4.3, 4.4_
+
+- [x] 10. Update test_tokens_dynamic.py to remove select_tokens() tests in test/test_preprocessing/test_tokens_dynamic.py
+  - File: `test/test_preprocessing/test_tokens_dynamic.py`
+  - Remove or refactor tests that specifically test `select_tokens()` method
+  - Tests to refactor (approximately 9 tests):
+    - test_select_tokens_* (all variants)
+  - For each test, either:
+    - Delete if testing select_tokens-specific behavior
+    - Refactor to test direct Tokens creation with selected keys if testing general slicing behavior
+  - Update or remove assertions on `label_map` (keep assertions on key_order via property)
+  - Purpose: Clean up tests for removed select_tokens method
+  - _Leverage: existing token creation utilities in conftest.py_
+  - _Requirements: 3.2, 5.1_
+
+- [x] 11. Update test_transformer.py fixtures to remove select_tokens() in test/test_nn/test_transformer/test_transformer.py
+  - File: `test/test_nn/test_transformer/test_transformer.py`
+  - Update `context_tokens` fixture (line 49) to create Tokens directly instead of using select_tokens
+  - Update `param_tokens` fixture (line 55) to create Tokens directly instead of using select_tokens
+  - Ensure resulting Tokens have same structure as before (same keys, slices, labels)
+  - Purpose: Adapt integration tests to use new Tokens creation approach
+  - _Leverage: Tokens.from_pytree() and fixtures_
+  - _Requirements: 5.2_
+
+- [x] 12. Verify pyright type checking passes in tfmpe/
+  - Command: `pyright tfmpe/preprocessing/`
+  - Ensure no new type errors introduced by:
+    - Labeller type annotations
+    - Tokens modifications (property)
+    - combine_tokens() changes
+  - Fix any type issues found
+  - Purpose: Ensure code quality standards met
+  - _Leverage: existing pyright configuration_
+  - _Requirements: Non-functional (Maintainability)_
+
+- [x] 13. Run all test suites to verify integration in test/
+  - Command: `python -m pytest test/` (all tests)
+  - Verify all tests pass including:
+    - test_preprocessing/ (new Labeller tests, updated Tokens tests)
+    - test_nn/ (transformer tests with updated fixtures)
+    - Any other integration tests
+  - Fix any failing tests
+  - Purpose: End-to-end validation of entire refactoring
+  - _Leverage: existing test infrastructure_
+  - _Requirements: 5.1, 5.2, 5.3, Non-functional (all)_

--- a/.claude/specs/transformer/design.md
+++ b/.claude/specs/transformer/design.md
@@ -1,0 +1,337 @@
+# Design Document
+
+## Overview
+
+The Transformer architecture provides the neural network backbone for TFMPE, implementing an encoder-decoder transformer that processes structured parameter data via the `Tokens` interface. Unlike the legacy implementation which required manual management of flattened arrays, labels, indices, and masks, this design leverages the unified `Tokens` API for cleaner integration with the preprocessing pipeline.
+
+The architecture consists of modular components (embedding, encoder blocks, decoder blocks) that are individually testable and configurable via a dataclass-based configuration system.
+
+## Steering Document Alignment
+
+### Technical Standards (tech.md)
+
+- **JAX/Flax**: All components use `flax.nnx` modules for neural network layers
+- **Type annotations**: Functions use `jaxtyping.Array` for array types
+- **Testing**: pytest for unit tests, pytest-benchmark for speed benchmarks, pytest-memray for memory profiling
+- **Documentation**: Numpy-style docstrings throughout
+- **Static analysis**: Code passes pyright type checking
+
+### Project Structure (structure.md)
+
+- **Location**: `tfmpe/nn/transformer/` following the documented structure
+- **Testing**: Tests in `test/test_nn/test_transformer/` with component-level organization
+- **Benchmarks**: Performance tests in `test/benchmark/` with `@pytest.mark.speed` and `@pytest.mark.scale` markers
+- **Imports**: Follows standard order (built-in, external, internal, types, constants)
+
+## Code Reuse Analysis
+
+### Existing Components to Leverage
+
+- **`tfmpe.preprocessing.Tokens`**: Core data structure for unified parameter handling
+  - Provides `data`, `labels`, `self_attention_mask`, `functional_inputs`
+  - Eliminates need for manual array management
+  - Supports `select_tokens()` for creating context/parameter views
+  - Supports `cross_attention_mask()` for encoder-decoder attention
+
+- **`tfmpe.preprocessing.TokenView`**: Efficient subset views into Tokens
+  - Used to separate context and parameter tokens
+  - Provides re-indexed slices and masks for subsets
+  - Lazy evaluation with cached properties
+
+- **Legacy transformer components** (`sfmpe_legacy/sfmpe/nn/transformer/`):
+  - Reference for GaussianFourierEmbedding implementation
+  - Reference for encoder/decoder block architecture
+  - Reference for MLP feedforward structure
+  - **NOTE**: Adapt patterns, don't copy violations of project standards
+
+### Integration Points
+
+- **Tokens API**: Primary input interface
+  - Transformer receives context and parameter `Tokens` objects
+  - Extracts data, labels, masks via properties
+  - Uses `cross_attention_mask()` for decoder attention
+
+- **Test patterns**: Follow existing test structure
+  - Shape tests similar to `test/test_preprocessing/test_tokens_basic.py`
+  - Use `@pytest.mark.parametrize` for input variations
+  - Mark slow tests with `@pytest.mark.slow`
+
+## Architecture
+
+```mermaid
+graph TD
+    A[Context Tokens] --> B[Embedding Layer]
+    C[Parameter Tokens] --> D[Embedding Layer]
+
+    B --> E[Encoder Blocks x N]
+    D --> F[Encoder Blocks x N]
+
+    E --> G[Encoded Context]
+    F --> H[Encoded Parameters]
+
+    H --> I[Decoder Blocks x M]
+    G --> I
+
+    I --> J[Linear Output Layer]
+    J --> K[Vector Field Output]
+
+    L[TransformerConfig] -.configures.-> B
+    L -.configures.-> E
+    L -.configures.-> F
+    L -.configures.-> I
+    L -.configures.-> J
+```
+
+## Components and Interfaces
+
+### TransformerConfig (Dataclass)
+
+- **Purpose:** Configuration container for transformer architecture parameters
+- **Module:** `tfmpe/nn/transformer/config.py`
+- **Attributes:**
+  ```python
+  @dataclass
+  class TransformerConfig:
+      latent_dim: int          # Hidden dimension size
+      n_encoder: int           # Number of encoder layers
+      n_decoder: int           # Number of decoder layers
+      n_heads: int             # Number of attention heads
+      n_ff: int                # Number of feedforward layers per block
+      label_dim: int           # Label embedding dimension
+      index_out_dim: int       # Index embedding output dimension
+      dropout: float           # Dropout rate
+      activation: Callable     # Activation function (e.g., nnx.relu)
+  ```
+- **Dependencies:** None (pure dataclass)
+- **Reuses:** Standard Python dataclass pattern
+
+### Embedding
+
+- **Purpose:** Embed token values, labels, indices, and time into latent space
+- **Module:** `tfmpe/nn/transformer/embedding.py`
+- **Interfaces:**
+  - `__init__(config, value_dim, n_labels, index_dim, rngs)`
+  - `__call__(values, labels, indices, time, functional_inputs=None) -> Array`
+- **Input shapes:**
+  - `values`: `(*sample_shape, n_tokens, value_dim)`
+  - `labels`: `(*sample_shape, n_tokens)` (int32)
+  - `indices`: `(*sample_shape, n_tokens, index_dim)` or None
+  - `time`: `(*sample_shape,)` scalar or `(*sample_shape, 1)` array
+  - `functional_inputs`: `(*sample_shape, n_tokens, value_dim)` or None
+- **Output shape:** `(*sample_shape, n_tokens, latent_dim)`
+- **Dependencies:**
+  - `flax.nnx.Embed` for label embeddings
+  - `flax.nnx.Linear` for final projection
+  - `GaussianFourierEmbedding` for index encoding
+- **Reuses:** Legacy `GaussianFourierEmbedding` pattern
+
+### GaussianFourierEmbedding
+
+- **Purpose:** Fourier feature encoding for continuous indices
+- **Module:** `tfmpe/nn/transformer/embedding.py`
+- **Interfaces:**
+  - `__init__(in_dim, out_dim, rngs)`
+  - `__call__(inputs) -> Array`
+- **Input shape:** `(..., in_dim)`
+- **Output shape:** `(..., out_dim)`
+- **Dependencies:** JAX for sin/cos operations
+- **Reuses:** Direct adaptation from legacy implementation
+
+### EncoderBlock
+
+- **Purpose:** Self-attention transformer block
+- **Module:** `tfmpe/nn/transformer/encoder.py`
+- **Interfaces:**
+  - `__init__(config, rngs)`
+  - `__call__(x, mask=None) -> Array`
+- **Input shape:** `(*sample_shape, n_tokens, latent_dim)`
+- **Output shape:** `(*sample_shape, n_tokens, latent_dim)`
+- **Architecture:**
+  - Multi-head self-attention
+  - Layer normalization
+  - MLP feedforward (n_ff layers)
+  - Residual connections
+- **Dependencies:**
+  - `flax.nnx.MultiHeadAttention`
+  - `flax.nnx.LayerNorm`
+  - `MLP` module
+- **Reuses:** Legacy encoder block pattern with updated API
+
+### DecoderBlock
+
+- **Purpose:** Cross-attention transformer block
+- **Module:** `tfmpe/nn/transformer/encoder.py`
+- **Interfaces:**
+  - `__init__(config, rngs)`
+  - `__call__(x, context, mask=None) -> Array`
+- **Input shapes:**
+  - `x`: `(*sample_shape, n_query_tokens, latent_dim)`
+  - `context`: `(*sample_shape, n_key_tokens, latent_dim)`
+- **Output shape:** `(*sample_shape, n_query_tokens, latent_dim)`
+- **Architecture:**
+  - Multi-head cross-attention (query=x, key/value=context)
+  - Layer normalization
+  - MLP feedforward
+  - Residual connections
+- **Dependencies:**
+  - `flax.nnx.MultiHeadAttention`
+  - `flax.nnx.LayerNorm`
+  - `MLP` module
+- **Reuses:** Legacy decoder block pattern
+
+### MLP
+
+- **Purpose:** Multi-layer feedforward network with dropout
+- **Module:** `tfmpe/nn/transformer/encoder.py`
+- **Interfaces:**
+  - `__init__(config, rngs)`
+  - `__call__(x) -> Array`
+- **Input shape:** `(..., latent_dim)`
+- **Output shape:** `(..., latent_dim)`
+- **Architecture:** n_ff sequential layers with dropout and activation
+- **Dependencies:**
+  - `flax.nnx.Linear`
+  - `flax.nnx.Dropout`
+- **Reuses:** Legacy MLP/FFLayer pattern with nnx.scan for layer iteration
+
+### Transformer
+
+- **Purpose:** Main transformer model coordinating all components
+- **Module:** `tfmpe/nn/transformer/transformer.py`
+- **Interfaces:**
+  - `__init__(config, value_dim, n_labels, index_dim, rngs)`
+  - `__call__(context_tokens, param_tokens, time) -> Array`
+  - `encode(tokens, time) -> Array`
+  - `decode(tokens, encoded_context, time) -> Array`
+- **Input:**
+  - `context_tokens`: Tokens object for context
+  - `param_tokens`: Tokens object for parameters
+  - `time`: `(*sample_shape,)` time scalar for flow matching
+- **Output shape:** `(*sample_shape, n_param_tokens, value_dim)`
+- **Architecture:**
+  1. Embed context tokens
+  2. Encode context through encoder blocks with self-attention
+  3. Embed parameter tokens
+  4. Encode parameters through encoder blocks with self-attention
+  5. Decode parameters with cross-attention to context through decoder blocks
+  6. Linear projection to value_dim
+- **Dependencies:** All above components
+- **Reuses:** Legacy transformer architecture adapted for Tokens API
+
+## Data Models
+
+### TransformerConfig
+
+```python
+@dataclass
+class TransformerConfig:
+    latent_dim: int = 128
+    n_encoder: int = 4
+    n_decoder: int = 4
+    n_heads: int = 8
+    n_ff: int = 2
+    label_dim: int = 32
+    index_out_dim: int = 64
+    dropout: float = 0.1
+    activation: Callable = nnx.relu
+```
+
+### Tokens (from preprocessing)
+
+Already implemented in `tfmpe.preprocessing.Tokens`. Key attributes used:
+
+- `data: Array` - Token values
+- `labels: Array` - Token type labels
+- `self_attention_mask: Array` - Self-attention mask
+- `functional_inputs: Optional[Array]` - Functional inputs
+- `sample_shape: Tuple[int, ...]` - Sample dimensions
+
+## Error Handling
+
+### Error Scenarios
+
+1. **Shape mismatch between context and parameter Tokens**
+   - **Handling:** Validate that both Tokens have same `sample_shape` in `__call__`
+   - **User Impact:** Clear ValueError with expected vs actual shapes
+
+2. **Time array incompatible with sample shape**
+   - **Handling:** Broadcast time to `(*sample_shape, 1)` if scalar, validate shape otherwise
+   - **User Impact:** ValueError indicating time shape requirements
+
+3. **Missing functional_inputs when expected**
+   - **Handling:** Embedding layer treats None functional_inputs as zeros or omits concatenation
+   - **User Impact:** Transparent - model works with or without functional inputs
+
+4. **Configuration with invalid dimensions**
+   - **Handling:** Validate `latent_dim % n_heads == 0` in TransformerConfig post-init
+   - **User Impact:** ValueError on configuration creation, not model initialization
+
+5. **Benchmark threshold exceeded**
+   - **Handling:** pytest assertion failure with measured vs threshold values
+   - **User Impact:** Test failure with clear performance regression message
+
+## Testing Strategy
+
+### Unit Testing
+
+**Location:** `test/test_nn/test_transformer/`
+
+**Component tests:**
+- `test_config.py`: Validate TransformerConfig dataclass
+  - Default values
+  - Invalid configurations (e.g., latent_dim not divisible by n_heads)
+
+- `test_embedding.py`: Test Embedding layer
+  - Output shape with/without indices
+  - Output shape with/without functional_inputs
+  - Time broadcasting
+  - Value range checks
+
+- `test_encoder.py`: Test EncoderBlock, DecoderBlock, MLP
+  - Output shapes preserved
+  - Mask application
+  - Gradients flow correctly
+
+- `test_transformer.py`: Test full Transformer
+  - End-to-end forward pass shape
+  - Encode method shape
+  - Decode method shape
+  - Integration with Tokens objects
+  - Backward pass (gradient computation)
+
+**Test patterns:**
+- Use `@pytest.mark.parametrize` for varying dimensions
+- Create fixture for sample Tokens objects
+- Verify shapes at each layer
+- Test with and without sample dimensions
+
+### Benchmark Testing
+
+**Location:** `test/benchmark/test_transformer_speed.py`, `test/benchmark/test_transformer_memory.py`
+
+**Speed benchmarks (pytest-benchmark):**
+- Forward pass timing
+- Backward pass timing (jax.grad)
+- Parameterized by: `n_tokens`, `latent_dim`, `n_encoder`, `n_decoder`
+- Markers: `@pytest.mark.speed` (standard configs), `@pytest.mark.scale` (large configs)
+- Asserts: execution time < threshold
+
+**Memory benchmarks (pytest-memray):**
+- Forward pass peak memory
+- Backward pass peak memory
+- Same parameterization as speed benchmarks
+- Markers: `@pytest.mark.speed`, `@pytest.mark.scale`
+- Asserts: peak memory < threshold (MB)
+
+### Integration Testing
+
+**Test full pipeline:**
+1. Create sample PyTree
+2. Convert to Tokens with independence structure
+3. Split into context/parameter views
+4. Run through transformer
+5. Verify output shape matches parameter tokens
+6. Compute gradient w.r.t. parameters
+7. Verify gradient shape matches parameter shape
+
+This validates the complete TFMPE workflow from structured data to gradient computation.

--- a/.claude/specs/transformer/requirements.md
+++ b/.claude/specs/transformer/requirements.md
@@ -1,0 +1,135 @@
+# Requirements Document
+
+## Introduction
+
+The Transformer feature implements a neural network architecture for Tokenised Flow Matching for Posterior Estimation (TFMPE). This transformer processes structured parameter data using an encoder-decoder architecture to generate vector fields for flow matching in simulation-based inference.
+
+Unlike the legacy implementation which accepts separate arrays for context and parameters, this implementation leverages the new `Tokens` unified data interface to handle structured parameter data, masking, and functional inputs coherently.
+
+## Alignment with Package Vision
+
+This feature directly supports the package's core goals:
+
+- **TFMPE Implementation**: Provides the neural network backbone for the tokenised estimator
+- **Data-preprocessing Integration**: Seamlessly works with the `Tokens` interface, eliminating manual parameter flattening and mask construction
+- **Scalability**: Addresses memory limitations through benchmarking and optimization, critical for large-scale hierarchical models
+- **Speed**: Includes execution time benchmarks to ensure fast training and inference
+
+## Requirements
+
+### Requirement 1: Tokens-based Interface
+
+**User Story:** As a scientist using TFMPE, I want the transformer to accept `Tokens` objects directly, so that I don't need to manually manage parameter flattening, labels, masks, and functional inputs.
+
+#### Acceptance Criteria
+
+1. WHEN the transformer is called THEN it SHALL accept a `Tokens` object for context data
+2. WHEN the transformer is called THEN it SHALL accept a `Tokens` object for parameter data
+3. WHEN processing Tokens objects THEN the transformer SHALL extract data, labels, masks, and functional inputs from the unified interface
+4. WHEN Tokens objects contain functional inputs THEN the transformer SHALL incorporate them into token embeddings
+5. WHEN Tokens objects specify independence structure THEN the transformer SHALL use the self-attention and cross-attention masks derived from that structure
+
+### Requirement 2: Encoder-Decoder Architecture
+
+**User Story:** As a scientist training a TFMPE model, I want an encoder-decoder transformer architecture that processes context separately from parameters, so that the model can effectively learn conditional distributions.
+
+#### Acceptance Criteria
+
+1. WHEN context tokens are provided THEN the encoder SHALL process them through multiple encoder blocks
+2. WHEN encoder blocks process tokens THEN they SHALL apply self-attention using the context self-attention mask
+3. WHEN parameter tokens are provided THEN the decoder SHALL first encode them through encoder blocks using parameter self-attention mask
+4. WHEN decoder processes tokens THEN it SHALL apply cross-attention between encoded parameters and encoded context using cross-attention mask
+5. WHEN the decoder completes THEN it SHALL output a vector field with shape matching the input parameter tokens
+
+### Requirement 3: Modular Components with Shape Testing
+
+**User Story:** As a developer maintaining the transformer, I want each component (embedding, encoder block, decoder block) tested for correct output shapes, so that I can catch shape mismatches early.
+
+#### Acceptance Criteria
+
+1. WHEN the embedding layer is called THEN it SHALL output shape `(*sample_shape, n_tokens, latent_dim)`
+2. WHEN an encoder block processes tokens THEN it SHALL preserve the input shape
+3. WHEN a decoder block processes tokens THEN it SHALL preserve the query token shape
+4. WHEN the final linear layer is called THEN it SHALL output shape `(*sample_shape, n_theta_tokens, value_dim)`
+5. WHEN any component is tested THEN the test SHALL verify the output shape matches the expected shape
+
+### Requirement 4: Dataclass-based Configuration
+
+**User Story:** As a scientist experimenting with model architectures, I want to configure the transformer using a dataclass with sensible defaults, so that I don't need to pass numerous parameters individually.
+
+#### Acceptance Criteria
+
+1. WHEN creating a configuration THEN it SHALL be a Python dataclass
+2. WHEN initializing the configuration THEN it SHALL include `n_encoder` (number of encoder layers)
+3. WHEN initializing the configuration THEN it SHALL include `n_decoder` (number of decoder layers)
+4. WHEN initializing the configuration THEN it SHALL include `n_heads` (number of attention heads)
+5. WHEN initializing the configuration THEN it SHALL include `n_ff` (number of feedforward layers)
+6. WHEN initializing the configuration THEN it SHALL include `latent_dim` (hidden dimension size)
+7. WHEN initializing the configuration THEN it SHALL include `dropout` (dropout rate)
+8. WHEN initializing the configuration THEN it SHALL include `activation` (activation function)
+9. WHEN initializing the configuration THEN it SHALL include `label_dim` (label embedding dimension)
+10. WHEN initializing the configuration THEN it SHALL include `index_out_dim` (index embedding output dimension)
+11. WHEN initializing the transformer THEN it SHALL accept the configuration dataclass as a single parameter
+12. WHEN initializing the transformer THEN it SHALL also accept `value_dim`, `n_labels`, `index_dim` as separate parameters derived from data
+
+### Requirement 5: Execution Time Benchmarking
+
+**User Story:** As a scientist working with large models, I want to benchmark transformer execution time for forward and backward passes, so that I can ensure training remains fast enough for my use case.
+
+#### Acceptance Criteria
+
+1. WHEN a speed benchmark is run THEN it SHALL use pytest-benchmark for statistical testing
+2. WHEN a speed benchmark measures forward pass THEN it SHALL time the compiled forward function
+3. WHEN a speed benchmark measures backward pass THEN it SHALL time `jax.grad` computation
+4. WHEN a benchmark is parameterized THEN it SHALL accept `n_tokens` (number of tokens)
+5. WHEN a benchmark is parameterized THEN it SHALL accept architecture parameters via configuration dataclass
+6. WHEN a benchmark is parameterized THEN it SHALL accept a `time_threshold` in seconds
+7. WHEN execution time exceeds threshold THEN the benchmark SHALL fail
+8. WHEN the benchmark runs THEN it SHALL compile the model first (excluding compilation from timing)
+9. WHEN reporting results THEN pytest-benchmark SHALL provide statistical summaries (mean, stddev, etc.)
+10. WHEN the benchmark is marked THEN it SHALL use `@pytest.mark.speed` for standard configurations
+11. WHEN the benchmark tests large configurations THEN it SHALL use `@pytest.mark.scale` marker
+
+### Requirement 6: Memory Usage Benchmarking
+
+**User Story:** As a scientist working with memory-constrained hardware, I want to benchmark transformer memory usage for forward and backward passes, so that I can ensure the model fits within available GPU memory.
+
+#### Acceptance Criteria
+
+1. WHEN a memory benchmark is run THEN it SHALL use pytest-memray for memory profiling
+2. WHEN a memory benchmark measures forward pass THEN it SHALL profile peak memory during forward execution
+3. WHEN a memory benchmark measures backward pass THEN it SHALL profile peak memory during `jax.grad` computation
+4. WHEN a benchmark is parameterized THEN it SHALL accept `n_tokens` (number of tokens)
+5. WHEN a benchmark is parameterized THEN it SHALL accept architecture parameters via configuration dataclass
+6. WHEN a benchmark is parameterized THEN it SHALL accept a `memory_threshold` in MB
+7. WHEN peak memory usage exceeds threshold THEN the benchmark SHALL fail
+8. WHEN reporting results THEN it SHALL output peak memory allocation in MB
+9. WHEN the benchmark is marked THEN it SHALL use `@pytest.mark.speed` for standard configurations
+10. WHEN the benchmark tests large configurations THEN it SHALL use `@pytest.mark.scale` marker
+
+## Non-Functional Requirements
+
+### Performance
+
+- Forward pass execution SHALL complete within time thresholds specified in benchmarks
+- Backward pass (gradient computation) SHALL complete within time thresholds specified in benchmarks
+- Memory usage SHALL stay within memory thresholds specified in benchmarks
+- All component tests SHALL run in under 5 seconds (excluding compilation)
+- The transformer SHALL be JIT-compilable with JAX for production use
+
+### Usability
+
+- The transformer interface SHALL be simpler than the legacy implementation by using `Tokens` objects
+- Configuration SHALL use a dataclass with sensible defaults to reduce boilerplate
+- Error messages SHALL clearly indicate shape mismatches when they occur
+- Documentation SHALL include examples of creating `Tokens` objects for transformer input
+
+### Maintainability
+
+- Each component (embedding, encoder, decoder) SHALL be in a separate module
+- All components SHALL use JAX/Flax type annotations (`Array` from jaxtyping)
+- All modules SHALL follow numpy-style docstrings
+- Tests SHALL be organized by component (embedding, encoder, decoder, transformer)
+- The codebase SHALL pass `pyright` type checking with no errors
+- Benchmark code SHALL be in `test/benchmark/` directory
+- The project SHALL add `pytest-memray` as a development dependency

--- a/.claude/specs/transformer/tasks.md
+++ b/.claude/specs/transformer/tasks.md
@@ -1,0 +1,300 @@
+# Implementation Plan
+
+## Task Overview
+
+This implementation follows a test-driven development approach, creating tests before implementations for each component. The transformer is built bottom-up: configuration � embedding � encoder/decoder blocks � full transformer � benchmarks. Each task is atomic, touching 1-3 related files and completable in 15-30 minutes.
+
+## Steering Document Compliance
+
+- **structure.md**: Code in `tfmpe/nn/transformer/`, tests in `test/test_nn/test_transformer/`, benchmarks in `test/benchmark/`
+- **tech.md**: Uses JAX/Flax, `jaxtyping.Array`, pytest, pytest-benchmark, pytest-memray, numpy docstrings
+- **Import order**: Built-in, external (jax, flax), internal (tfmpe), types, constants
+
+## Atomic Task Requirements
+
+**Each task meets:**
+- **File Scope**: 1-3 related files maximum
+- **Time Boxing**: 15-30 minutes per task
+- **Single Purpose**: One testable outcome
+- **Specific Files**: Exact file paths specified
+- **Agent-Friendly**: Clear inputs/outputs, minimal context switching
+
+## Tasks
+
+### 1. Configuration Module
+
+- [ ] 1.1 Create test for TransformerConfig dataclass in test/test_nn/test_transformer/test_config.py
+  - File: test/test_nn/test_transformer/test_config.py (create)
+  - Test default values instantiation
+  - Test custom configuration values
+  - Test that latent_dim divisible by n_heads (validation in __post_init__)
+  - Test ValueError when latent_dim not divisible by n_heads
+  - Purpose: Verify configuration dataclass behavior before implementation
+  - _Requirements: 4.1-4.10_
+
+- [ ] 1.2 Implement TransformerConfig dataclass in tfmpe/nn/transformer/config.py
+  - File: tfmpe/nn/transformer/config.py (create)
+  - Create @dataclass with fields: latent_dim, n_encoder, n_decoder, n_heads, n_ff, label_dim, index_out_dim, dropout, activation
+  - Add default values matching design.md
+  - Add __post_init__ to validate latent_dim % n_heads == 0
+  - Include numpy-style docstring
+  - Purpose: Configuration container for transformer architecture
+  - _Leverage: tfmpe/preprocessing/tokens.py (dataclass pattern)_
+  - _Requirements: 4.1-4.10_
+
+### 2. Embedding Module
+
+- [ ] 2.1 Create test for GaussianFourierEmbedding in test/test_nn/test_transformer/test_embedding.py
+  - File: test/test_nn/test_transformer/test_embedding.py (create)
+  - Test output shape: input (..., in_dim) � output (..., out_dim)
+  - Test with different input shapes using @pytest.mark.parametrize
+  - Test that output contains both sin and cos components
+  - Purpose: Verify Gaussian Fourier embedding shape and behavior
+  - _Requirements: 3.1_
+
+- [ ] 2.2 Implement GaussianFourierEmbedding in tfmpe/nn/transformer/embedding.py
+  - File: tfmpe/nn/transformer/embedding.py (create)
+  - Implement nnx.Module with random Gaussian matrix for frequency basis
+  - __call__ computes sin/cos of 2� * input @ basis
+  - Concatenate cos and sin components
+  - Include numpy-style docstring with shape specifications
+  - Purpose: Fourier feature encoding for continuous indices
+  - _Leverage: sfmpe_legacy/sfmpe/nn/transformer/embedding.py (reference)_
+  - _Requirements: 3.1_
+
+- [ ] 2.3 Add tests for Embedding layer to test_embedding.py
+  - File: test/test_nn/test_transformer/test_embedding.py (modify)
+  - Test output shape without indices: input (batch, n_tokens, value_dim) � (batch, n_tokens, latent_dim)
+  - Test output shape with indices
+  - Test output shape with functional_inputs
+  - Test time broadcasting from scalar to (batch, 1)
+  - Test with sample dimensions: (samples, batch, n_tokens, value_dim)
+  - Purpose: Verify embedding layer handles all input variations
+  - _Requirements: 3.1, 1.4_
+
+- [ ] 2.4 Implement Embedding layer in embedding.py
+  - File: tfmpe/nn/transformer/embedding.py (modify)
+  - __init__ creates nnx.Embed for labels, GaussianFourierEmbedding for indices, nnx.Linear for projection
+  - __call__ concatenates: values + label_embeds + (optional index_embeds) + (optional functional_inputs) + time
+  - Apply linear projection to latent_dim
+  - Broadcast time and labels to match batch dimensions
+  - Include numpy-style docstring
+  - Purpose: Embed token data into latent space
+  - _Leverage: sfmpe_legacy/sfmpe/nn/transformer/embedding.py (reference)_
+  - _Requirements: 3.1, 1.4_
+
+### 3. Encoder/Decoder Blocks
+
+- [x] 3.1 Create test for MLP in test/test_nn/test_transformer/test_encoder.py
+  - File: test/test_nn/test_transformer/test_encoder.py (create)
+  - Test output shape preservation: (batch, n_tokens, latent_dim) � (batch, n_tokens, latent_dim)
+  - Test with different n_ff values using @pytest.mark.parametrize
+  - Test dropout in train vs eval mode
+  - Purpose: Verify MLP feedforward network before encoder/decoder
+  - _Requirements: 3.2_
+
+- [x] 3.2 Implement MLP module in tfmpe/nn/transformer/encoder.py
+  - File: tfmpe/nn/transformer/encoder.py (create)
+  - Create FFLayer with nnx.Linear, nnx.Dropout, activation
+  - Use nnx.vmap and nnx.scan to create n_ff layers
+  - __call__ applies layers sequentially using nnx.scan
+  - Include numpy-style docstring
+  - Purpose: Multi-layer feedforward with dropout
+  - _Leverage: sfmpe_legacy/sfmpe/nn/transformer/encoder.py (reference)_
+  - _Requirements: 3.2_
+
+- [x] 3.3 Add test for EncoderBlock to test_encoder.py
+  - File: test/test_nn/test_transformer/test_encoder.py (modify)
+  - Test output shape preserved
+  - Test self-attention with mask (verify mask zeros out connections)
+  - Purpose: Verify encoder block before full transformer
+  - _Requirements: 2.2, 3.2_
+
+- [x] 3.4 Implement EncoderBlock in encoder.py
+  - File: tfmpe/nn/transformer/encoder.py (modify)
+  - __init__ creates nnx.MultiHeadAttention, nnx.LayerNorm, MLP
+  - __call__ applies: self_attention + residual + norm + MLP + residual + norm
+  - Use config for n_heads, latent_dim, dropout
+  - Include numpy-style docstring
+  - Purpose: Self-attention transformer block
+  - _Leverage: sfmpe_legacy/sfmpe/nn/transformer/encoder.py (reference)_
+  - _Requirements: 2.2, 3.2_
+
+- [x] 3.5 Add test for DecoderBlock to test_encoder.py
+  - File: test/test_nn/test_transformer/test_encoder.py (modify)
+  - Test output shape: query (batch, n_q, latent_dim) → (batch, n_q, latent_dim)
+  - Test cross-attention with mask
+  - Purpose: Verify decoder block cross-attention
+  - _Requirements: 2.4, 3.2_
+
+- [x] 3.6 Implement DecoderBlock in encoder.py
+  - File: tfmpe/nn/transformer/encoder.py (modify)
+  - __init__ creates nnx.MultiHeadAttention, nnx.LayerNorm, MLP
+  - __call__ applies: cross_attention(query=x, key=context, value=context) + residual + norm + MLP + residual + norm
+  - Include numpy-style docstring
+  - Purpose: Cross-attention transformer block
+  - _Leverage: sfmpe_legacy/sfmpe/nn/transformer/encoder.py (reference)_
+  - _Requirements: 2.4, 3.2_
+
+### 4. Main Transformer
+
+- [x] 4.1 Create test for Transformer in test/test_nn/test_transformer/test_transformer.py
+  - File: test/test_nn/test_transformer/test_transformer.py (create)
+  - Create fixture for sample Tokens objects (context and parameters)
+  - Test __init__ accepts config dataclass
+  - Test forward pass output shape: (batch, n_param_tokens, value_dim)
+  - Test with sample dimensions: (samples, batch, ...)
+  - Test encode method output shape
+  - Test decode method output shape
+  - Use @pytest.mark.parametrize for varying n_tokens, latent_dim
+  - Purpose: Verify transformer before implementation
+  - _Leverage: test/test_preprocessing/test_tokens_basic.py (Tokens fixtures)_
+  - _Requirements: 1.1-1.5, 2.1-2.5, 3.4_
+
+- [x] 4.2 Implement Transformer.__init__ in tfmpe/nn/transformer/transformer.py
+  - File: tfmpe/nn/transformer/transformer.py (create)
+  - __init__ creates: Embedding, n_encoder EncoderBlocks via nnx.vmap, n_decoder DecoderBlocks via nnx.vmap, output Linear
+  - Accept config: TransformerConfig, value_dim, n_labels, index_dim, rngs
+  - Include numpy-style class and __init__ docstrings
+  - Purpose: Initialize transformer components
+  - _Leverage: sfmpe_legacy/sfmpe/nn/transformer/transformer.py (reference)_
+  - _Requirements: 1.1-1.5, 4.11-4.12_
+
+- [x] 4.3 Implement Transformer.encode method in transformer.py
+  - File: tfmpe/nn/transformer/transformer.py (modify)
+  - Extract data, labels from Tokens object
+  - Embed tokens with time
+  - Apply encoder blocks sequentially using nnx.scan with self_attention_mask
+  - Return encoded array
+  - Include numpy-style docstring with shapes
+  - Purpose: Encode context or parameter tokens
+  - _Requirements: 2.1-2.2_
+
+- [x] 4.4 Implement Transformer.decode method in transformer.py
+  - File: tfmpe/nn/transformer/transformer.py (modify)
+  - Embed parameter tokens with time
+  - Encode parameters with encoder blocks
+  - Decode with decoder blocks using cross-attention to encoded_context
+  - Apply output linear layer
+  - Return vector field array
+  - Include numpy-style docstring with shapes
+  - Purpose: Decode parameters conditioned on context
+  - _Requirements: 2.3-2.5_
+
+- [x] 4.5 Implement Transformer.__call__ method in transformer.py
+  - File: tfmpe/nn/transformer/transformer.py (modify)
+  - Validate context_tokens.sample_shape == param_tokens.sample_shape
+  - Encode context tokens
+  - Decode parameter tokens with encoded context
+  - Return vector field output
+  - Include numpy-style docstring
+  - Purpose: End-to-end forward pass through transformer
+  - _Requirements: 1.1-1.5, 2.5_
+
+- [x] 4.6 Update tfmpe/nn/transformer/__init__.py to export classes
+  - File: tfmpe/nn/transformer/__init__.py (modify)
+  - Import and expose: TransformerConfig, Transformer
+  - Update __all__ list
+  - Purpose: Make transformer accessible from package
+  - _Requirements: Usability_
+
+### 5. Integration Testing
+
+- [ ] 5.1 Create integration test in test/test_nn/test_transformer/test_integration.py
+  - File: test/test_nn/test_transformer/test_integration.py (create)
+  - Create PyTree � Tokens � split to context/param views
+  - Initialize Transformer with config
+  - Forward pass through transformer
+  - Verify output shape matches param_tokens.data shape
+  - Compute gradient w.r.t. transformer parameters using jax.grad
+  - Verify gradient dict has expected keys
+  - Purpose: Test complete TFMPE pipeline integration
+  - _Leverage: test/test_preprocessing/test_tokens_basic.py (Tokens creation)_
+  - _Requirements: 1.1-1.5, Integration Testing_
+
+### 6. Speed Benchmarks
+
+- [ ] 6.1 Create forward pass speed benchmark in test/benchmark/test_transformer_speed.py
+  - File: test/benchmark/test_transformer_speed.py (create)
+  - Use pytest-benchmark fixture
+  - Create benchmark function accepting n_tokens, config parameters
+  - Compile transformer forward pass with jax.jit
+  - Benchmark compiled function (exclude compilation time)
+  - Use @pytest.mark.speed for standard configs (n_tokens=100, latent_dim=128)
+  - Assert execution time < threshold (e.g., 0.1s)
+  - Purpose: Measure and enforce forward pass speed
+  - _Requirements: 5.1-5.11_
+
+- [ ] 6.2 Add backward pass speed benchmark to test_transformer_speed.py
+  - File: test/benchmark/test_transformer_speed.py (modify)
+  - Create jax.grad function for transformer
+  - Compile gradient computation with jax.jit
+  - Benchmark compiled gradient function
+  - Use @pytest.mark.speed marker
+  - Assert gradient computation time < threshold (e.g., 0.2s)
+  - Purpose: Measure and enforce backward pass speed
+  - _Requirements: 5.1-5.11_
+
+- [ ] 6.3 Add large-scale speed benchmarks to test_transformer_speed.py
+  - File: test/benchmark/test_transformer_speed.py (modify)
+  - Create benchmarks with large configs (n_tokens=1000, latent_dim=512, n_encoder=8)
+  - Use @pytest.mark.scale marker
+  - Test both forward and backward passes
+  - Higher time thresholds for large configs
+  - Purpose: Ensure transformer scales to large problems
+  - _Requirements: 5.10-5.11_
+
+### 7. Memory Benchmarks
+
+- [ ] 7.1 Create forward pass memory benchmark in test/benchmark/test_transformer_memory.py
+  - File: test/benchmark/test_transformer_memory.py (create)
+  - Use @pytest.mark.limit_memory decorator from pytest-memray
+  - Create function executing transformer forward pass
+  - Set memory limit (e.g., 100 MB for standard config)
+  - Use @pytest.mark.speed for standard configs
+  - Purpose: Measure and enforce forward pass memory usage
+  - _Requirements: 6.1-6.10_
+
+- [ ] 7.2 Add backward pass memory benchmark to test_transformer_memory.py
+  - File: test/benchmark/test_transformer_memory.py (modify)
+  - Use pytest-memray to profile gradient computation
+  - Set memory limit for backward pass (typically higher than forward)
+  - Use @pytest.mark.speed marker
+  - Purpose: Measure and enforce backward pass memory
+  - _Requirements: 6.1-6.10_
+
+- [ ] 7.3 Add large-scale memory benchmarks to test_transformer_memory.py
+  - File: test/benchmark/test_transformer_memory.py (modify)
+  - Create benchmarks with large configs (n_tokens=1000, latent_dim=512)
+  - Use @pytest.mark.scale marker
+  - Higher memory limits for large configs (e.g., 500 MB)
+  - Purpose: Ensure memory efficiency on large problems
+  - _Requirements: 6.9-6.10_
+
+### 8. Final Verification
+
+- [ ] 8.1 Run pyright type checking on transformer module
+  - Command: `pyright tfmpe/nn/transformer/`
+  - Verify no type errors
+  - Fix any type annotation issues
+  - Purpose: Ensure type safety and maintainability
+  - _Requirements: Maintainability (pyright)_
+
+- [ ] 8.2 Run all transformer tests
+  - Command: `python -m pytest test/test_nn/test_transformer/ -v`
+  - Verify all unit and integration tests pass
+  - Fix any failures
+  - Purpose: Ensure all components work correctly
+  - _Requirements: All_
+
+- [ ] 8.3 Run speed benchmarks (excluding scale)
+  - Command: `python -m pytest test/benchmark/ -m "speed" -v`
+  - Verify benchmarks pass time thresholds
+  - Purpose: Ensure performance meets requirements
+  - _Requirements: 5.10, 6.9_
+
+- [ ] 8.4 Run memory benchmarks (excluding scale)
+  - Command: `python -m pytest test/benchmark/ -m "speed" -v --memray`
+  - Verify benchmarks pass memory thresholds
+  - Purpose: Ensure memory efficiency
+  - _Requirements: 6.9_

--- a/.claude/specs/viewless/design.md
+++ b/.claude/specs/viewless/design.md
@@ -1,0 +1,274 @@
+# Design Document: Remove TokenView and Enhance Token Updates
+
+## Overview
+
+This refactoring consolidates the token abstraction layer by removing the `TokenView` class and enhancing the `Tokens` class with:
+1. A `select_tokens()` method that returns sliced `Tokens` instead of `TokenView`
+2. A `with_data()` method for full data vector replacement
+3. Simplified type signatures throughout the codebase
+
+The design supports the core flow: instantiate all `Tokens`, select subsets (context/params), update params via `with_data()` during ODE integration.
+
+## Steering Document Alignment
+
+### Technical Standards (tech.md)
+- **Type Annotations**: Eliminate `Union[Tokens, TokenView]` everywhere, using only `Tokens`
+- **Functions over Classes**: Leverage dataclass structure; no new class hierarchy
+- **Code Quality**: Removal of defensive type-checking improves maintainability and enables true duck typing
+
+### Project Structure (structure.md)
+- **Preprocessing module**: Consolidates to single token abstraction
+- **Modified files**: `tfmpe/preprocessing/tokens.py` (core changes)
+- **Removed files**: `tfmpe/preprocessing/token_view.py`
+- **Updated files**: `tfmpe/nn/transformer/embedding.py`, `tfmpe/nn/transformer/transformer.py`, `tfmpe/estimators/ode.py`
+
+## Code Reuse Analysis
+
+### Existing Components to Leverage
+- **`update_flat_array()`** (flatten.py): Already flattens and inserts data at key offsets; used by `with_values()`, reuse for `with_data()`
+- **`SliceInfo` metadata**: Unchanged structure; used for all slicing operations and re-indexing
+- **`build_self_attention_mask()` / `build_cross_attention_mask()`** (masks.py): Existing mask builders work with re-indexed slices
+- **`decode_pytree()` / `decode_pytree_keys()`** (reconstruct.py): Reconstruction logic unchanged
+- **`flatten_pytree()`** (flatten.py): Used for initial token creation; logic reused for sliced tokens
+
+### Integration Points
+- **Transformer Embedding** (`embedding.py`): Remove `TokenView` import; update type hints from `Union[Tokens, TokenView]` to `Tokens`
+- **Transformer** (`transformer.py`): Update `encode()`, `decode()`, `forward()` signatures; `cross_attention_mask()` method exists on `Tokens`
+- **ODE Solvers** (`estimators/ode.py`): Update signatures to accept context and params; vector field now `Callable[[Tokens, Tokens, Scalar], Tokens]`
+
+## Architecture
+
+```mermaid
+graph TD
+    A["Create Tokens<br/>(all variables)"] -->|select_tokens| B["Context Tokens<br/>(sliced, re-indexed)"]
+    A -->|select_tokens| C["Param Tokens<br/>(sliced, re-indexed)"]
+
+    B -->|fixed| G["ODE Integration<br/>(context passed to vf_fn)"]
+    C -->|evolving| G
+
+    G -->|vf_fn: context, params, t -> params| H["Vector Field Function<br/>(transformer)"]
+    H -->|outputs new params| I["Updated Param Tokens<br/>(via with_data)"]
+    I -->|feeds back| G
+
+    style A fill:#e1f5ff
+    style B fill:#fff3e0
+    style C fill:#fff3e0
+    style G fill:#f3e5f5
+    style H fill:#f3e5f5
+    style I fill:#e8f5e9
+```
+
+## Components and Interfaces
+
+### Tokens Class Enhancements
+
+#### `select_tokens(keys: List[str]) -> Tokens`
+- **Purpose**: Create a sliced view of tokens containing only specified keys (replaces `TokenView`)
+- **Implementation**:
+  1. Validate all keys exist in `self.key_order`
+  2. Compute token indices for selected keys from slice metadata
+  3. Extract data slice using advanced indexing: `self.data[..., indices, :]`
+  4. Extract label slice: `self.labels[..., indices]`
+  5. Extract padding mask slice (if present): `self.padding_mask[..., indices]`
+  6. Extract functional inputs slice (if present): `self.functional_inputs[..., indices, :]`
+  7. Extract self-attention mask submatrix: `self.self_attention_mask[ix_(indices, indices)]`
+  8. **Re-index slices**: Compute new slice offsets starting from 0
+  9. Return new `Tokens` with sliced data and re-indexed metadata
+- **Key Invariant**: Returned `Tokens` has offsets starting at 0, enabling seamless downstream use
+- **Dependencies**: Uses `SliceInfo` logic, `jnp.ix_()` for mask extraction
+
+#### `with_data(new_data: Array) -> Tokens`
+- **Purpose**: Create new `Tokens` with entirely replaced data vector (used in ODE integration)
+- **Signature**: `def with_data(self, new_data: Array) -> 'Tokens'`
+- **Implementation**:
+  1. Validate `new_data.shape == self.data.shape`
+  2. Return new `Tokens` object with:
+     - `data=new_data`
+     - All other fields unchanged (labels, masks, slices, metadata)
+- **Usage Pattern**: `param_tokens = param_tokens.with_data(vf_fn(param_tokens, t).data)`
+- **Dependencies**: None (simple replacement)
+- **Error Handling**: Raise `ValueError` if shape mismatch with helpful message
+
+### Remove TokenView Class
+- **File Deletion**: Delete `tfmpe/preprocessing/token_view.py` entirely
+- **Cleanup**: Remove all imports of `TokenView` from:
+  - `tfmpe/preprocessing/__init__.py` (if exported)
+  - `tfmpe/nn/transformer/embedding.py`
+  - `tfmpe/nn/transformer/transformer.py`
+
+### Update Transformer Integration
+
+#### Embedding (`embedding.py`)
+- **Current**: `def __call__(self, tokens: Union[Tokens, TokenView], ...):`
+- **New**: `def __call__(self, tokens: Tokens, ...):`
+- **Change**: Remove `TokenView` from union type; logic unchanged (both had same `.data`, `.labels`, `.functional_inputs`)
+
+#### Transformer (`transformer.py`)
+- **Remove import**: `from ...preprocessing.token_view import TokenView`
+- **Update `encode()` signature**:
+  - Current: `tokens: Union[Tokens, TokenView]`
+  - New: `tokens: Tokens`
+- **Update `decode()` signature**:
+  - Current: `tokens: Union[Tokens, TokenView]`
+  - New: `tokens: Tokens`
+- **Update `forward()` signature**:
+  - Current: `context: TokenView, params: TokenView`
+  - New: `context: Tokens, params: Tokens`
+- **No logic changes**: `tokens.self_attention_mask` and `cross_attention_mask()` method work identically
+
+### Update ODE Solver Signatures
+
+#### Current Signatures (ode.py)
+```python
+def solve_forward_ode(
+    vf_fn: Callable[[Array, Scalar], Array],  # (x, t) -> array
+    x0: Array,
+    ...
+) -> Array
+```
+
+#### New Signatures (ode.py)
+```python
+def solve_forward_ode(
+    vf_fn: Callable[[Tokens, Tokens, Scalar], Tokens],  # (context, params, t) -> params
+    context: Tokens,
+    params: Tokens,
+    ...
+) -> Tokens
+```
+
+**Changes apply to**:
+- `solve_forward_ode()`
+- `solve_backward_ode()`
+- `solve_augmented_ode()`
+- `batch_solve_forward_ode()`
+- `batch_solve_augmented_ode()`
+
+**Implementation Details**:
+- Vector field function now accepts:
+  - `context: Tokens` - Fixed context tokens (e.g., observations)
+  - `params: Tokens` - Parameter tokens being evolved
+  - `t: Scalar` - Time value
+  - Returns: Updated `params` as `Tokens`
+- Inner `ode_func()` receives augmented state and calls `vf_fn(context, y_params, t)`
+- diffrax integration: `y0` is `params` (a `Tokens` object), JAX pytree registration handles this
+- Return values become `Tokens` objects directly
+- Context remains fixed throughout ODE integration (passed to vf_fn at each step)
+
+## Data Models
+
+### Tokens Structure (Unchanged)
+```
+Tokens:
+  data: Array                      # shape (*sample, n_tokens, max_batch)
+  labels: Array                    # shape (*sample, n_tokens)
+  self_attention_mask: Array       # shape (n_tokens, n_tokens)
+  padding_mask: Optional[Array]    # shape (*sample, n_tokens)
+  functional_inputs: Optional[Array] # shape (*sample, n_tokens, max_batch)
+  slices: Dict[str, SliceInfo]     # token metadata per key
+  label_map: Dict[str, int]        # key -> label integer mapping
+  key_order: List[str]             # ordered key names
+  independence: Optional[Independence]  # attention rules
+```
+
+### SliceInfo (Unchanged)
+```
+SliceInfo:
+  offset: int                      # position in flattened token array
+  event_shape: Tuple[int, ...]     # shape of token events
+  batch_shape: Tuple[int, ...]     # shape in batch dimension
+```
+
+## Error Handling
+
+### Error Scenarios
+
+1. **Invalid Key Selection in `select_tokens()`**
+   - **Scenario**: Key not in `self.key_order`
+   - **Handling**: Raise `KeyError("Key '{key}' not found. Available: {self.key_order}")`
+   - **User Impact**: Clear guidance on available keys
+
+2. **Shape Mismatch in `with_data()`**
+   - **Scenario**: `new_data.shape != self.data.shape`
+   - **Handling**: Raise `ValueError(f"Shape mismatch: expected {self.data.shape}, got {new_data.shape}")`
+   - **User Impact**: Prevents silent corruption; clear expected vs actual
+
+3. **Empty Key Selection**
+   - **Scenario**: `select_tokens([])` called with empty list
+   - **Handling**: Raise `ValueError("Cannot select empty key list")`
+   - **User Impact**: Prevents creation of degenerate tokens
+
+4. **ODE Vector Field Type Mismatch**
+   - **Scenario**: Vector field returns `Array` instead of `Tokens`
+   - **Handling**: JAX pytree error at diffrax integration; caught early
+   - **User Impact**: Type system guides correct implementation
+
+## Testing Strategy
+
+### Unit Testing
+
+**Tokens Slicing (repurposed TokenView tests)**
+- `test_select_tokens_returns_tokens`: Verify returns `Tokens` class, not `TokenView`
+- `test_select_tokens_subset_data`: Data extraction with correct indices
+- `test_select_tokens_subset_labels`: Label extraction correctness
+- `test_select_tokens_subset_padding_mask`: Padding mask slicing
+- `test_select_tokens_subset_functional_inputs`: Functional inputs slicing
+- `test_select_tokens_self_attention_mask`: Correct submatrix extraction via `ix_`
+- `test_select_tokens_slices_reindexed`: Verify offsets re-indexed to 0
+- `test_select_tokens_cross_attention_mask`: Cross-attention computation with re-indexed slices
+- `test_select_tokens_single_key`: Single-key selection
+- `test_select_tokens_invalid_key_raises`: Error on invalid key
+- `test_select_tokens_empty_raises`: Error on empty selection
+
+**Tokens Direct Updates**
+- `test_with_data_full_replacement`: Complete data replacement
+- `test_with_data_preserves_metadata`: Verify labels, masks, slices unchanged
+- `test_with_data_preserves_independence`: Independence spec unchanged
+- `test_with_data_shape_validation`: Shape mismatch raises `ValueError`
+- `test_with_data_sample_dims`: Works with sample dimensions
+- `test_with_data_roundtrip`: Update and retrieve via decode
+
+**Backward Compatibility**
+- `test_with_values_still_works`: Keep `with_values()` working during transition (can be deprecated later)
+
+### Integration Testing
+- `test_transformer_encode_with_sliced_tokens`: Embedding/encoder works with sliced `Tokens`
+- `test_transformer_decode_with_sliced_tokens`: Decoder works with cross-attention on sliced `Tokens`
+- `test_ode_solver_tokens_vector_field`: ODE solver accepts `Tokens` vector field
+- `test_select_decode_consistency`: `select_tokens().decode()` matches original behavior
+
+### End-to-End Testing
+- `test_training_loop_with_sliced_tokens`: Full forward pass (encode context, decode params with cross-attention)
+- `test_ode_integration_with_tokens`: Forward/backward ODE integration using `Tokens` vector fields
+
+### Test Consolidation Strategy
+- **No new test classes**: All testing happens in `test_tokens_basic.py` and `test_tokens_dynamic.py`
+- **TokenView tests → Tokens tests**: Directly modify existing `TokenView` test functions to test `select_tokens()` on `Tokens`
+- **No duplication**: If `test_select_tokens_subset_data` already exists, modify it rather than create a duplicate
+- **Remove redundancy**: Tests for properties that work identically on both classes should verify once (on `Tokens`)
+
+## Implementation Notes
+
+### JAX Pytree Registration
+`Tokens` is already registered with `@register_pytree_node_class`. The `tree_flatten()` and `tree_unflatten()` methods handle:
+- **Children** (arrays with sample dimension): `data`, `labels`, `padding_mask`, `functional_inputs`
+- **Aux data** (static metadata): `self_attention_mask`, `slices`, `label_map`, `key_order`, `independence`
+
+This ensures diffrax can work with `Tokens` directly in ODE solvers.
+
+### Re-indexing in `select_tokens()`
+When creating sliced tokens, compute new slice offsets:
+```python
+reindexed = {}
+current_offset = 0
+for key in selected_keys:
+    slice_info = self.slices[key]
+    n_tokens = 1
+    for dim in slice_info.event_shape:
+        n_tokens *= dim
+    reindexed[key] = slice_info._replace(offset=current_offset)
+    current_offset += n_tokens
+```
+
+This pattern is already in `TokenView._compute_slices()` and will be moved to `Tokens.select_tokens()`.
+

--- a/.claude/specs/viewless/requirements.md
+++ b/.claude/specs/viewless/requirements.md
@@ -1,0 +1,89 @@
+# Requirements Document: Remove TokenView and Enhance Token Updates
+
+## Introduction
+
+This refactoring addresses fundamental design flaws in the token abstraction layer:
+1. **Incorrect type contracts** - Vector field functions assume `Array` input when they should accept `Tokens`
+2. **Cumbersome abstraction** - `TokenView`'s lazy slicing philosophy conflicts with continuous flow requirements that need frequent token updates
+3. **Type barriers** - Alternate types (`TokenView` vs `Token`) force defensive type-checking instead of duck typing
+
+The solution removes `TokenView` entirely and adds direct data vector update methods to `Tokens`.
+
+## Alignment with Package Vision
+
+TFMPE's success depends on efficient continuous flow matching with frequent parameter updates. The current design creates friction in the update path. By simplifying to a single cohesive abstraction (`Tokens` only), we improve:
+- **Maintainability**: Eliminate defensive type checks; rely on structural typing
+- **Efficiency**: Streamline the update path for continuous flows
+- **Clarity**: Single consistent interface reduces cognitive overhead
+
+## Requirements
+
+### Requirement 1: Remove TokenView Class and Preserve select_tokens Functionality
+
+**User Story:** As a developer, I want to eliminate the `TokenView` class while preserving its slicing functionality, so that I have a single consistent token abstraction without type-checking friction.
+
+#### Acceptance Criteria
+
+1. WHEN `select_tokens()` is called THEN it SHALL return a new `Tokens` object (not `TokenView`) containing only selected keys
+2. IF data is sliced from parent's flat array THEN the returned `Tokens` SHALL have re-indexed slice metadata (offsets starting at 0)
+3. WHEN accessing properties on sliced `Tokens` THEN they SHALL work identically to original implementation (data, labels, masks, slices)
+4. IF the `TokenView` class is removed THEN imports and module references SHALL be cleaned up entirely
+
+### Requirement 2: Update Vector Field Function Signatures
+
+**User Story:** As a user, I want vector field functions to accept `Tokens` directly, so that type contracts match actual usage patterns.
+
+#### Acceptance Criteria
+
+1. WHEN a vector field function is defined THEN it SHALL accept `Tokens` as first parameter (not `Array`)
+2. IF transformer outputs vector field THEN it SHALL return output shaped/typed for `Tokens` consumption
+3. WHEN ODE solvers call vector fields THEN they SHALL pass `Tokens` directly
+4. IF documentation specifies function signatures THEN it SHALL reflect `Tokens` parameter
+
+### Requirement 3: Add Direct Data Vector Update Method to Tokens
+
+**User Story:** As a developer using continuous flows, I want a direct method to update the entire token data vector, so that I can efficiently replace parameter tokens during training/sampling.
+
+#### Acceptance Criteria
+
+1. WHEN updating a token data vector THEN there SHALL be a method that accepts the new flat array directly (not through keys)
+2. WHEN using the update method THEN data consistency SHALL be maintained (labels, masks, slices unchanged)
+3. IF shape validation fails THEN validation errors SHALL provide clear messaging
+4. WHEN vector field function returns updated `Tokens` THEN it replaces the entire state seamlessly
+
+### Requirement 4: Update All Call Sites
+
+**User Story:** As a maintainer, I want all code calling `TokenView` or using old vector field signatures to be updated, so that the system is internally consistent.
+
+#### Acceptance Criteria
+
+1. WHEN code previously called `select_tokens()` THEN it SHALL work identically with new `Tokens`-returning version
+2. IF code previously extracted data from `TokenView` THEN it SHALL work with returned `Tokens` directly
+3. WHEN tests verify token operations THEN redundant tests SHALL be eliminated to avoid duplication
+4. IF type errors arise during refactoring THEN they SHALL be resolved before completion
+
+### Requirement 5: Consolidate Tests Without Redundancy
+
+**User Story:** As a test maintainer, I want to repurpose `TokenView` tests into `Tokens` tests without creating redundant coverage, so that test suite remains lean and maintainable.
+
+#### Acceptance Criteria
+
+1. WHEN `TokenView` tests are repurposed THEN shared functionality tests SHALL be merged with `Tokens` tests
+2. IF both `TokenView` and `Tokens` tested identical operations THEN only one test instance SHALL remain
+3. WHEN testing slicing functionality THEN tests SHALL verify behavior on `Tokens` directly (not separate class)
+4. IF test coverage remains complete THEN no functionality from original tests SHALL be lost
+
+## Non-Functional Requirements
+
+### Performance
+- No degradation in test execution time
+- No increase in memory usage from token operations
+
+### Maintainability
+- All type annotations remain valid (`pyright` passes)
+- Code readability improved by removing defensive type checks
+- Update path simplified and more direct
+
+### Usability
+- Duck typing works naturally (no `isinstance` checks needed)
+- Clear method names for update operations

--- a/.claude/specs/viewless/tasks.md
+++ b/.claude/specs/viewless/tasks.md
@@ -1,0 +1,213 @@
+# Implementation Plan: Remove TokenView and Enhance Token Updates
+
+## Task Overview
+
+This implementation removes the `TokenView` class and enhances the `Tokens` class with slicing and data update capabilities. Tasks proceed in dependency order:
+1. Add `select_tokens()` and `with_data()` methods to `Tokens`
+2. Update ODE solver signatures to accept context and params
+3. Update transformer to remove `TokenView` type hints
+4. Consolidate tests without redundancy
+5. Remove `TokenView` module and clean up imports
+
+## Steering Document Compliance
+
+- **tech.md**: All type annotations use `Tokens` directly (no `Union` types); no new class hierarchy
+- **structure.md**: Single cohesive token abstraction in `tfmpe/preprocessing/tokens.py`; cleanup of `token_view.py`
+
+## Atomic Task Requirements
+
+Each task:
+- Touches 1-3 related files maximum
+- Completable in 15-30 minutes
+- Has one testable outcome
+- Specifies exact file paths
+- Minimizes context switching
+
+## Tasks
+
+- [x] 1. Modify `select_tokens()` method to return Tokens instead of TokenView
+  - **Files**: `tfmpe/preprocessing/tokens.py`
+  - **Implementation**:
+    - Locate existing `select_tokens()` method (currently returns `TokenView`)
+    - Modify to compute and return `Tokens` object instead:
+      - Compute token indices for selected keys using slice metadata
+      - Extract data slice: `self.data[..., indices, :]`
+      - Extract labels slice: `self.labels[..., indices]`
+      - Extract padding_mask slice if present
+      - Extract functional_inputs slice if present
+      - Extract self_attention_mask submatrix using `jnp.ix_(indices, indices)`
+      - Re-index slice metadata: compute new offsets starting from 0
+      - Return new `Tokens` object with sliced data and re-indexed metadata
+    - Keep existing validation (selected keys must exist; raise `KeyError` if not)
+  - **Tests**: Will be validated by `test_select_tokens_*` suite
+  - _Leverage: `SliceInfo` namedtuple, existing logic currently in `TokenView._token_indices`, `TokenView.slices`, etc._
+  - _Requirements: 1.1_
+
+- [ ] 2. Add `with_data()` method to Tokens class
+  - **Files**: `tfmpe/preprocessing/tokens.py`
+  - **Implementation**:
+    - Add method that takes `new_data: Array` parameter
+    - Validate `new_data.shape == self.data.shape`; raise `ValueError` with helpful message if not
+    - Return new `Tokens` with:
+      - `data=new_data`
+      - All other fields unchanged (labels, masks, slices, metadata, independence)
+    - Keep implementation simple (no complex logic)
+  - **Tests**: Will be validated by `test_with_data_*` suite
+  - _Leverage: None (straightforward replacement)_
+  - _Requirements: 3.1_
+
+- [x] 3. Update `solve_forward_ode()` signature in ODE module
+  - **Files**: `tfmpe/estimators/ode.py`
+  - **Implementation**:
+    - Update function signature to accept `context: Tokens, params: Tokens`
+    - Update docstring to document new parameters
+    - Update inner `ode_func()` to receive params state and call `vf_fn(context, y_params, t)`
+    - Extract returned params object and integrate with diffrax
+    - Ensure context is passed unchanged through ODE integration
+  - **Tests**: Will be validated by ODE solver tests
+  - _Leverage: Existing diffrax integration pattern_
+  - _Requirements: 2.1_
+
+- [x] 4. Update `solve_backward_ode()` signature in ODE module
+  - **Files**: `tfmpe/estimators/ode.py`
+  - **Implementation**:
+    - Update function signature to accept `context: Tokens, params: Tokens`
+    - Update docstring to document new parameters
+    - Update inner `ode_func()` to call `vf_fn(context, y_params, 1.0 - t)` with negation
+    - Ensure context remains fixed during backward integration
+  - **Tests**: Will be validated by ODE solver tests
+  - _Leverage: Existing backward ODE pattern_
+  - _Requirements: 2.1_
+
+- [x] 5. Update `solve_augmented_ode()` signature in ODE module
+  - **Files**: `tfmpe/estimators/ode.py`
+  - **Implementation**:
+    - Update function signature to accept `context: Tokens, params: Tokens`
+    - Update docstring to document new parameters
+    - Update `augmented_ode_func()` to call `vf_fn(context, x, actual_time)`
+    - Preserve trace estimation logic (unchanged)
+    - Ensure context passed at each step
+  - **Tests**: Will be validated by augmented ODE tests
+  - _Leverage: Existing FFJORD implementation_
+  - _Requirements: 2.1_
+
+- [ ] 6. Update `batch_solve_forward_ode()` signature in ODE module
+  - **Files**: `tfmpe/estimators/ode.py`
+  - **Implementation**:
+    - Update function signature to accept `context: Tokens, params_batch: Tokens`
+    - Update docstring
+    - Use `jax.vmap()` over `solve_forward_ode()` for batch dimension
+    - Handle vmap correctly with context (not vmapped) and params batch (vmapped)
+  - **Tests**: Will be validated by batch ODE tests
+  - _Leverage: Existing vmap pattern_
+  - _Requirements: 2.1_
+
+- [ ] 7. Update `batch_solve_augmented_ode()` signature in ODE module
+  - **Files**: `tfmpe/estimators/ode.py`
+  - **Implementation**:
+    - Update function signature to accept `context: Tokens, params_batch: Tokens`
+    - Update docstring
+    - Use `jax.vmap()` over `solve_augmented_ode()` correctly
+    - Handle RNG splitting for batch dimension
+  - **Tests**: Will be validated by batch augmented ODE tests
+  - _Leverage: Existing vmap pattern_
+  - _Requirements: 2.1_
+
+- [x] 8. Update Embedding class type hints
+  - **Files**: `tfmpe/nn/transformer/embedding.py`
+  - **Implementation**:
+    - Remove import: `from ...preprocessing.token_view import TokenView`
+    - Update `__call__()` signature: change `tokens: Union[Tokens, TokenView]` to `tokens: Tokens`
+    - Update docstring to reference `Tokens` only
+    - No logic changes (properties work identically)
+  - **Tests**: Existing embedding tests should still pass
+  - _Leverage: No changes needed to logic_
+  - _Requirements: 4.1_
+
+- [x] 9. Update Transformer class type hints and methods
+  - **Files**: `tfmpe/nn/transformer/transformer.py`
+  - **Implementation**:
+    - Remove import: `from ...preprocessing.token_view import TokenView`
+    - Update `encode()` signature: change `tokens: Union[Tokens, TokenView]` to `tokens: Tokens`
+    - Update `decode()` signature: change `tokens: Union[Tokens, TokenView]` to `tokens: Tokens`
+    - Update `forward()` signature: change `context: TokenView, params: TokenView` to `context: Tokens, params: Tokens`
+    - Update all docstrings to reference `Tokens` only
+    - No logic changes (method calls work identically)
+  - **Tests**: Existing transformer tests should still pass
+  - _Leverage: No changes needed to logic_
+  - _Requirements: 4.1_
+
+- [x] 10. Repurpose TokenView tests to test Tokens.select_tokens()
+  - **Files**: `test/test_preprocessing/test_tokens_dynamic.py`
+  - **Implementation**:
+    - Modify existing `test_select_tokens_*` functions to test `Tokens.select_tokens()` instead of `TokenView`
+    - Change assertions from `isinstance(view, TokenView)` to `isinstance(sliced, Tokens)`
+    - Keep all validation logic identical (data, labels, masks, slices)
+    - Delete duplicate test functions (keep only one version per behavior)
+    - Add new test: `test_select_tokens_slices_reindexed()` to verify offset re-indexing
+    - Examples of tests to consolidate:
+      - `test_select_tokens_subset_data`
+      - `test_select_tokens_subset_labels`
+      - `test_select_tokens_self_attention_mask`
+      - `test_tokenview_decode_consistent_with_tokens` → rename to `test_select_tokens_decode`
+  - **Tests**: All modified tests should pass
+  - _Leverage: Existing test logic from `TokenView` tests_
+  - _Requirements: 5.1_
+
+- [ ] 11. Add tests for Tokens.with_data()
+  - **Files**: `test/test_preprocessing/test_tokens_dynamic.py`
+  - **Implementation**:
+    - Add `test_with_data_full_replacement()`: verify data is replaced, shape validated
+    - Add `test_with_data_preserves_metadata()`: verify labels, masks, slices unchanged
+    - Add `test_with_data_preserves_independence()`: verify independence spec unchanged
+    - Add `test_with_data_shape_validation()`: verify shape mismatch raises ValueError
+    - Add `test_with_data_sample_dims()`: verify works with sample dimensions
+    - Each test follows existing test patterns (fixtures, assertions)
+  - **Tests**: All new tests should pass
+  - _Leverage: Existing test fixtures and patterns_
+  - _Requirements: 3.1_
+
+- [ ] 12. Run type checking and fix type errors
+  - **Files**: `tfmpe/` (all modified files)
+  - **Implementation**:
+    - Run `pyright` on entire codebase
+    - Fix any type errors from signature changes
+    - Verify no `Union[Tokens, TokenView]` references remain
+    - Ensure all function parameters correctly typed
+  - **Tests**: `pyright` should pass with no errors
+  - _Leverage: No changes to code logic, only type annotations_
+  - _Requirements: 4.1_
+
+- [ ] 13. Run test suite to verify no regressions
+  - **Files**: `test/` (entire test directory)
+  - **Implementation**:
+    - Run `python -m pytest test/ -m "not slow"` to verify fast tests pass
+    - Run `python -m pytest test/test_preprocessing/` specifically to verify token tests
+    - Fix any test failures arising from changes
+    - Verify no redundant tests exist (consolidation successful)
+  - **Tests**: All tests should pass
+  - _Leverage: Existing pytest setup_
+  - _Requirements: 5.1_
+
+- [x] 14. Delete TokenView module and clean up imports
+  - **Files**: `tfmpe/preprocessing/token_view.py`, `tfmpe/preprocessing/__init__.py`
+  - **Implementation**:
+    - Delete file: `tfmpe/preprocessing/token_view.py`
+    - Remove from `__init__.py`: any exports of `TokenView`
+    - Verify no remaining imports of `token_view` module in codebase (should have been removed in tasks 8-9)
+    - Use grep/search to confirm no orphaned references
+  - **Tests**: Type checker and imports should pass
+  - _Leverage: No changes needed_
+  - _Requirements: 1.1_
+
+- [x] 15. Verify complete integration
+  - **Files**: `tfmpe/` (all files)
+  - **Implementation**:
+    - Run full test suite: `python -m pytest test/ -m "not slow"`
+    - Run `pyright` to verify all type checking passes
+    - Verify no import errors or orphaned references to `TokenView`
+    - Document any behavioral changes in docstrings
+  - **Tests**: All tests pass, no type errors, clean imports
+  - _Leverage: Existing CI/testing infrastructure_
+  - _Requirements: 4.1, 5.1_
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "jax>=0.8.0,<0.9.0",
-    "flax>=0.10.0,<0.11.0",
+    "jax>=0.9.0",
+    "flax>=0.11.0",
     "optax>=0.1.3",
     "jaxtyping>=0.2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "jax>=0.8.0,<0.9.0",
-    "flax>=0.8.0,<0.11.0",
+    "flax>=0.10.0,<0.11.0",
     "optax>=0.1.3",
     "jaxtyping>=0.2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "jax>=0.8.0",
-    "flax>=0.8.0",
+    "jax>=0.8.0,<0.9.0",
+    "flax>=0.8.0,<0.11.0",
     "optax>=0.1.3",
     "jaxtyping>=0.2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
     "flax>=0.11.0",
     "optax>=0.1.3",
     "jaxtyping>=0.2.0",
+    "diffrax>=0.7.0",
+    "tqdm>=4.67.3",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "jax>=0.9.0",
-    "flax>=0.11.0",
+    "jax[cuda12]==0.9.2",
+    "flax==0.12.6",
     "optax>=0.1.3",
     "jaxtyping>=0.2.0",
     "diffrax>=0.7.0",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,1 @@
 # Test configuration for TFMPE package
-import os
-
-# Use platform allocator so GPU OOM errors immediately instead of
-# retrying indefinitely via the BFC allocator.
-os.environ.setdefault("XLA_PYTHON_CLIENT_ALLOCATOR", "platform")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,1 +1,6 @@
 # Test configuration for TFMPE package
+import os
+
+# Use platform allocator so GPU OOM errors immediately instead of
+# retrying indefinitely via the BFC allocator.
+os.environ.setdefault("XLA_PYTHON_CLIENT_ALLOCATOR", "platform")

--- a/test/test_estimators/__init__.py
+++ b/test/test_estimators/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for estimator modules."""

--- a/test/test_estimators/conftest.py
+++ b/test/test_estimators/conftest.py
@@ -1,0 +1,37 @@
+"""Shared fixtures for estimator tests."""
+
+from jaxtyping import Array
+import diffrax
+import jax.numpy as jnp
+import pytest
+
+from tfmpe.preprocessing.tokens import Tokens
+
+@pytest.fixture
+def doubling_vf():
+    """Vector field for doubling flow: f(context, params, t)
+    -> Array.
+
+    For testing, ignores context and applies log(2) · params.data.
+    """
+    def vf(tokens: Tokens, t):
+        return jnp.log(2.0) * tokens.data[:, tokens.partition_idx:]
+    return vf
+
+
+@pytest.fixture
+def solver():
+    """Diffrax ODE solver instance."""
+    return diffrax.Dopri5()
+
+
+def create_mock_tokens(
+        context: Array,
+        params: Array,
+        sample_ndims:int = 0
+    ):
+    return Tokens.from_pytree(
+        {'x': params, 'y': context},
+        condition=['y'],
+        sample_ndims=sample_ndims
+    )

--- a/test/test_estimators/test_cfm_loss.py
+++ b/test/test_estimators/test_cfm_loss.py
@@ -1,0 +1,180 @@
+"""Unit tests for CFM loss function."""
+
+import jax
+import jax.numpy as jnp
+import pytest
+from flax import nnx
+
+from tfmpe.estimators.tfmpe import TFMPE, NormalDistribution
+from tfmpe.estimators.training import _cfm_loss as cfm_loss
+from tfmpe.preprocessing.tokens import Tokens
+from jaxtyping import Array
+
+
+class SimpleVectorField:
+    """Simple deterministic vector field for testing."""
+
+    def __call__(self, tokens: Tokens,
+                 t: Array) -> Array:
+        """Return scaled params as velocity."""
+        return jnp.tanh(tokens.data[:, tokens.partition_idx:] / 10.0)
+
+
+class TestCFMLossBatched:
+    """Test CFM loss function with batched inputs."""
+
+    @pytest.fixture
+    def vf_network(self):
+        """Simple vector field for testing."""
+        return SimpleVectorField()
+
+    @pytest.fixture
+    def tfmpe_instance(self, vf_network):
+        """TFMPE instance with simple vector field."""
+        rngs = nnx.Rngs(params=jax.random.PRNGKey(0))
+        base_dist = NormalDistribution(rngs=rngs)
+        return TFMPE(
+            vf_network=vf_network,
+            base_dist=base_dist,
+        )
+
+    def test_cfm_loss_batched_returns_scalar(
+        self, tfmpe_instance: TFMPE
+    ) -> None:
+        """Test cfm_loss with batched inputs returns scalar.
+
+        Given:
+        - TFMPE instance
+        - Batched theta and context Tokens (batch_size=4)
+        - Batched times with shape (4,)
+
+        When:
+        - Compute cfm_loss()
+
+        Then:
+        - Loss is a scalar (shape ())
+        - Loss is finite
+        """
+        batch_size = 4
+        state_dim = 10
+        context_dim = 5
+
+        # Create batched tokens
+        theta_data = jax.random.normal(
+            jax.random.PRNGKey(42), (batch_size, state_dim)
+        )
+        context_data = jax.random.normal(
+            jax.random.PRNGKey(43), (batch_size, context_dim)
+        )
+        tokens = Tokens.from_pytree(
+            {
+                'x': theta_data,
+                'y': context_data
+            },
+            condition=['y'],
+            sample_ndims=1,
+        )
+
+        losses = cfm_loss(
+            tfmpe_instance,
+            tokens,
+            jax.random.key(0)
+        )
+
+        # Check per-sample losses shape
+        assert len(losses.shape) == 0
+
+        # Check all finite
+        assert jnp.all(jnp.isfinite(losses)), (
+            "Losses contain NaN or Inf"
+        )
+
+    def test_cfm_loss_is_non_negative(
+        self, tfmpe_instance: TFMPE
+    ) -> None:
+        """Test CFM loss is non-negative (MSE property).
+
+        Given:
+        - TFMPE instance with batched data
+        - Multiple random times
+
+        When:
+        - Compute loss for different batch configurations
+
+        Then:
+        - All losses are non-negative
+        """
+        batch_size = 8
+        state_dim = 10
+        context_dim = 5
+
+        # Create batched data
+        theta_data = jax.random.normal(
+            jax.random.PRNGKey(42), (batch_size, state_dim)
+        )
+        context_data = jax.random.normal(
+            jax.random.PRNGKey(43), (batch_size, context_dim)
+        )
+        tokens = Tokens.from_pytree(
+            {
+                'x': theta_data,
+                'y': context_data
+            },
+            condition=['y'],
+            sample_ndims=1,
+        )
+
+        # Test multiple random time batches
+        for i in range(5):
+            losses = cfm_loss(
+                tfmpe_instance,
+                tokens,
+                jax.random.key(i)
+            )
+            assert jnp.all(losses >= 0), (
+                f"Losses are negative at iteration {i}: {losses}"
+            )
+
+    @pytest.mark.parametrize("batch_size", [1, 2, 8, 16])
+    def test_cfm_loss_different_batch_sizes(
+        self, tfmpe_instance: TFMPE, batch_size: int
+    ) -> None:
+        """Test cfm_loss works with different batch sizes.
+
+        Given:
+        - TFMPE instance
+        - batch_size in [1, 2, 8, 16]
+
+        When:
+        - Compute loss with batched inputs
+
+        Then:
+        - Succeeds and produces scalar output
+        """
+        state_dim = 10
+        context_dim = 5
+
+        # Create batched data
+        theta_data = jax.random.normal(
+            jax.random.PRNGKey(42), (batch_size, state_dim)
+        )
+        context_data = jax.random.normal(
+            jax.random.PRNGKey(43), (batch_size, context_dim)
+        )
+        tokens = Tokens.from_pytree(
+            {
+                'x': theta_data,
+                'y': context_data
+            },
+            condition=['y'],
+            sample_ndims=1,
+        )
+
+        losses = cfm_loss(
+            tfmpe_instance,
+            tokens,
+            jax.random.key(0)
+        )
+
+        assert len(losses.shape) == 0
+        assert jnp.all(jnp.isfinite(losses))

--- a/test/test_estimators/test_cfm_loss.py
+++ b/test/test_estimators/test_cfm_loss.py
@@ -6,7 +6,7 @@ import pytest
 from flax import nnx
 
 from tfmpe.estimators.tfmpe import TFMPE, NormalDistribution
-from tfmpe.estimators.training import _cfm_loss as cfm_loss
+from tfmpe.estimators.training.loss import cfm_loss
 from tfmpe.preprocessing.tokens import Tokens
 from jaxtyping import Array
 

--- a/test/test_estimators/test_e2e_training.py
+++ b/test/test_estimators/test_e2e_training.py
@@ -1,0 +1,529 @@
+"""End-to-end training tests for TFMPE.
+
+Tests complete training pipelines on realistic hierarchical models
+with both speed-optimized and memory-efficient training loops.
+"""
+
+import diffrax
+import jax
+import jax.numpy as jnp
+import optax
+import pytest
+from flax import nnx
+
+from tfmpe.estimators.tfmpe import TFMPE, NormalDistribution
+from tfmpe.estimators.training import fit_bottom_up, _cfm_loss
+from tfmpe.nn.training import fit_fast
+from tfmpe.preprocessing.tokens import Tokens
+from tfmpe.preprocessing.utils import Labeller
+from tfmpe.nn.transformer import Transformer, TransformerConfig
+from jaxtyping import Array
+
+def create_hierarchical_gaussian_data(
+    rng: Array,
+    n_groups: int = 10,
+    n_obs: int = 20,
+    n_samples: int = 1,
+) -> Tokens:
+    """Generate hierarchical Gaussian linear model data.
+
+    Parameters
+    ----------
+    rng : PRNGKeyArray
+        Random number generator key
+    n_groups : int
+        Number of groups (local parameters)
+    n_obs : int
+        Number of observations per group
+    n_samples : int
+        Number of samples to generate (batched)
+
+    Returns
+    -------
+    tuple[Tokens, Tokens]
+        (params_tokens, context_tokens) where:
+        - params_tokens contains sigma and mu
+        - context_tokens contains y (observations)
+
+    Model
+    -----
+    sigma ~ HalfNormal(1)
+    mu_i ~ Normal(0, 1) for i in 1..n_groups
+    y_ij ~ Normal(mu_i, sigma) for j in 1..n_obs
+    """
+
+    # Generate sigma (n_samples,)
+    rng, key = jax.random.split(rng)
+    sigma = jnp.abs(jax.random.normal(key, (n_samples,))) + 0.1
+
+    # Generate mu (n_samples, n_groups)
+    rng, key = jax.random.split(rng)
+    mu = jax.random.normal(key, (n_samples, n_groups))
+
+    # Generate y (n_samples, n_groups, n_obs)
+    rng, key = jax.random.split(rng)
+    noise = jax.random.normal(
+        key, (n_samples, n_groups, n_obs)
+    )
+    # Broadcast sigma and mu to match noise shape
+    y = (
+        noise * sigma[:, None, None] +
+        mu[:, :, None]
+    )
+    # Reshape to (n_samples, n_groups * n_obs)
+    y = y.reshape(n_samples, n_groups * n_obs)
+
+    # Create params Token with shape (n_samples, n_tokens, 1)
+    params_dict = {
+        'sigma': sigma[:, None, None],  # (n_samples, 1, 1)
+        'mu': mu[..., None],  # (n_samples, n_groups, 1)
+    }
+    context_dict = {
+        'y': y[..., None],  # (n_samples, n_groups * n_obs, 1)
+    }
+    tokens = Tokens.from_pytree(
+        {
+            **params_dict,
+            **context_dict
+        },
+        condition=['y'],
+        sample_ndims=1,
+    )
+
+    return tokens
+
+class TestE2ETrainingBottomUp:
+    """Test fit_bottom_up() multi-round bottom-up training."""
+
+    # Test parameters
+    n_groups: int = 2
+    n_obs: int = 2
+
+    @pytest.fixture
+    def prior_fn(self):
+        """Create prior function that accepts n_groups parameter.
+
+        Returns a function that samples parameters from prior:
+        sigma ~ HalfNormal(1)
+        mu_i ~ Normal(0, 1) for i in 1..n_groups
+
+        Parameterized by n to enable sample efficiency in bottom-up
+        algorithm (n=1 for local likelihood, n=n_groups for global).
+        """
+        def _prior_fn(
+            rng: Array,
+            n: int,
+            n_samples: int = 10,
+            *args
+        ) -> dict:
+            k1, k2 = jax.random.split(rng)
+
+            # sigma: shape (n_samples, 1, 1)
+            sigma = (
+                jnp.abs(jax.random.normal(k1, (n_samples,))) + 0.1
+            )
+            sigma = sigma[:, None, None]
+
+            # mu: shape (n_samples, n, 1)
+            mu = jax.random.normal(k2, (n_samples, n))
+            mu = mu[..., None]
+
+            return {'sigma': sigma, 'mu': mu}
+
+        return _prior_fn
+
+    @pytest.fixture
+    def simulator_fn(self):
+        """Create simulator function that accepts n_groups parameter.
+
+        Returns a function that generates observations given parameters:
+        y ~ Normal(mu, sigma)
+
+        Parameterized by n to enable sample efficiency in bottom-up
+        algorithm (n=1 for local likelihood, n=n_groups for global).
+        """
+        def _simulator_fn(
+            rng: Array,
+            params_dict: dict,
+            n: int,
+            *args
+        ) -> dict:
+            sigma = params_dict['sigma']
+            mu = params_dict['mu']
+            n_samples = sigma.shape[0]
+
+            # Generate noise
+            rng, key = jax.random.split(rng)
+            noise = jax.random.normal(
+                key, (n_samples, n, self.n_obs)
+            )
+
+            # Simulate observations: y = mu + sigma * noise
+            # Handle shapes: sigma (n_samples, 1, 1),
+            # mu (n_samples, n, 1)
+            y = noise * sigma + mu
+            # Add batch dimension: (n_samples, n, n_obs, 1)
+            y = y[..., None]
+
+            return {'y': y}
+
+        return _simulator_fn
+
+    @pytest.fixture
+    def local_fn(self):
+        """Create local prior function for bottom-up algorithm.
+
+        Generates local parameters given global parameters and
+        number of local groups.
+        """
+        def _local_fn(
+            rng: Array,
+            global_samples: dict,
+            n: int,
+            *args
+        ) -> dict:
+            """Sample local parameters.
+
+            Parameters
+            ----------
+            rng : PRNGKeyArray
+                Random number generator key
+            global_samples : dict
+                Global parameter samples (e.g., {'sigma': ...})
+            n : int
+                Number of local groups to generate
+
+            Returns
+            -------
+            dict
+                Local parameters dict with mu shape (n_samples, n, 1)
+            """
+            n_samples = global_samples['sigma'].shape[0]
+            mu = jax.random.normal(rng, (n_samples, n, 1))
+            return {'mu': mu}
+
+        return _local_fn
+
+    @pytest.fixture
+    def labeller(self) -> Labeller:
+        # Create global labeller with all keys
+        return Labeller.for_keys(['sigma', 'mu', 'y'])
+
+    @pytest.fixture
+    def tfmpe_instance(self, prior_fn, simulator_fn, labeller) -> TFMPE:
+        """TFMPE with Transformer vector field."""
+        # Generate training data using prior_fn/simulator_fn
+        rng = jax.random.PRNGKey(42)
+        rng, key = jax.random.split(rng)
+        train_params = prior_fn(key, n=10, n_samples=10)
+        context_params = simulator_fn(key, train_params, n=10)
+
+        # Convert to Tokens
+        train_params_tokens = Tokens.from_pytree(
+            {**train_params, **context_params},
+            condition=list(context_params.keys()),
+            sample_ndims=1,
+            labeller=labeller
+        )
+
+        config = TransformerConfig(
+            latent_dim=16,
+            n_encoder=1,
+            n_heads=1,
+            n_ff=2,
+        )
+
+        rngs = nnx.Rngs(
+            params=jax.random.PRNGKey(0),
+            dropout=jax.random.PRNGKey(1),
+        )
+        transformer = Transformer(
+            config=config,
+            tokens=train_params_tokens,
+            rngs=rngs,
+        )
+
+        base_dist = NormalDistribution(rngs=rngs)
+
+        return TFMPE(
+            vf_network=transformer,
+            base_dist=base_dist,
+            solver=diffrax.Dopri5(),
+        )
+
+    @pytest.mark.slow
+    def test_fit_bottom_up_trains_successfully(
+        self,
+        tfmpe_instance: TFMPE,
+        prior_fn,
+        simulator_fn,
+        local_fn,
+        labeller
+    ) -> None:
+        """Test fit_bottom_up() trains without errors.
+
+        Given:
+        - TFMPE instance
+        - prior_fn, simulator_fn, and local_fn fixtures
+
+        When:
+        - Call fit_bottom_up() with n_rounds=2, n_samples=10,
+          n_groups=10
+
+        Then:
+        - Training completes without errors
+        - Returns trained TFMPE instance
+        - Returns list of 2 loss tuples (one per round)
+        - All losses are finite
+        """
+
+
+        # Generate y_obs using simulator_fn with full n_groups
+        rng = jax.random.PRNGKey(42)
+        rng, key = jax.random.split(rng)
+        params = prior_fn(key, n=self.n_groups, n_samples=1)
+        rng, key = jax.random.split(rng)
+        y_obs = simulator_fn(key, params, n=self.n_groups)
+
+        optimizer = optax.adam(learning_rate=1e-3)
+        opt = nnx.Optimizer(tfmpe_instance, optimizer, wrt=nnx.Param)
+        rng = jax.random.PRNGKey(42)
+
+        trained_tfmpe, all_losses = fit_bottom_up(
+            tfmpe=tfmpe_instance,
+            y_obs=y_obs,
+            simulator_fn=simulator_fn,
+            prior_fn=prior_fn,
+            local_fn=local_fn,
+            global_names=['sigma'],
+            n_groups=self.n_groups,
+            n_rounds=1,
+            n_samples_per_round=100,
+            n_val_samples=10,
+            opt=opt,
+            n_iter_per_round=100,
+            batch_size=100,
+            rng=rng,
+            labeller=labeller,
+            prior_log_prob=lambda x: 1.
+        )
+
+        # Check TFMPE instance returned
+        assert isinstance(trained_tfmpe, TFMPE), (
+            f"Expected TFMPE instance, got {type(trained_tfmpe)}"
+        )
+
+        # Check losses is list of 4-tuples
+        assert isinstance(all_losses, list), (
+            f"Expected losses to be list, got {type(all_losses)}"
+        )
+        assert len(all_losses) == 1, (
+            f"Expected 1 loss tuple (Round 0 only), "
+            f"got {len(all_losses)}"
+        )
+
+        # Check each round's losses (4-tuple) are finite
+        for round_idx, loss_tuple in enumerate(all_losses):
+            assert len(loss_tuple) == 4, (
+                f"Round {round_idx}: Expected 4-tuple, "
+                f"got {len(loss_tuple)}"
+            )
+            train_loss_local, val_loss_local, (
+                train_loss_global
+            ), val_loss_global = loss_tuple
+
+            assert jnp.all(jnp.isfinite(train_loss_local)), (
+                f"Round {round_idx}: Local train losses contain NaN/Inf"
+            )
+            assert jnp.all(jnp.isfinite(val_loss_local)), (
+                f"Round {round_idx}: Local val losses contain NaN/Inf"
+            )
+            assert jnp.all(jnp.isfinite(train_loss_global)), (
+                f"Round {round_idx}: Global train losses contain NaN/Inf"
+            )
+            assert jnp.all(jnp.isfinite(val_loss_global)), (
+                f"Round {round_idx}: Global val losses contain NaN/Inf"
+            )
+
+class TestE2ETrainingHalfNormal:
+    """Test fit_fast() learns simple Gaussian target N(0, 2).
+
+    Tests that TFMPE can learn to transform from base distribution
+    N(0, 1) to target distribution N(0, 2), verifying both the
+    learned vector field and posterior samples.
+    """
+
+    @pytest.fixture(params=[1, 5, 10])
+    def n_dim(self, request):
+        """Parameterize test across different dimensions."""
+        return request.param
+
+    @pytest.fixture
+    def gaussian_training_data(self, n_dim, labeller) -> Tokens:
+        """Generate (params, context) for HalfNormal(0, 1) target.
+
+        Token shapes: (n_samples, n_tokens, 1) where n_tokens = n_dim
+        """
+        rng = jax.random.PRNGKey(42)
+        n_samples = 1000  # Sufficient for training
+
+        # Generate params from TARGET distribution N(0, 2)
+        # Shape: (n_samples, n_dim, 1) where n_dim tokens, dim=1
+        rng, key = jax.random.split(rng)
+        params_data = {
+            'y': jnp.abs(jax.random.normal(key, (n_samples, 1, 1))),
+            'x': jax.random.normal(key, (n_samples, n_dim, 1))
+        }
+
+        # Generate independent context from N(0, 1)
+        # Shape: (n_samples, 1, 1) where 1 token, dim=1
+        rng, key = jax.random.split(rng)
+        context_data = jax.random.normal(key, (n_samples, 1, 1))
+
+        # Convert to Tokens
+        tokens = Tokens.from_pytree(
+            {**params_data, **{'c': context_data}},
+            condition=['c'],
+            sample_ndims=1,
+            labeller=labeller
+        )
+
+        return tokens
+
+    @pytest.fixture
+    def labeller(self) -> Labeller:
+        return Labeller.for_keys(['x', 'y', 'c'])
+
+    @pytest.fixture
+    def gaussian_validation_data(self, n_dim, labeller) -> Tokens:
+        """Generate validation data for HalfNormal(0, 1) target."""
+        rng = jax.random.PRNGKey(100)
+        n_samples = 20  # Fewer samples for validation
+
+        # Generate params from TARGET distribution HalfNormal(0, 1)
+        rng, key = jax.random.split(rng)
+        params_data = {
+            'y': jnp.abs(jax.random.normal(key, (n_samples, 1, 1))),
+            'x': jax.random.normal(key, (n_samples, n_dim, 1)),
+        }
+
+        # Generate independent context from N(0, 1)
+        rng, key = jax.random.split(rng)
+        context_data = jax.random.normal(key, (n_samples, 1, 1))
+
+        # Convert to Tokens
+        tokens = Tokens.from_pytree(
+            {**params_data, **{'c': context_data}},
+            condition=['c'],
+            sample_ndims=1,
+            labeller=labeller
+        )
+
+        return tokens
+
+    @pytest.fixture
+    def gaussian_tfmpe_instance(
+        self,
+        gaussian_training_data
+    ) -> TFMPE:
+        """TFMPE instance for Gaussian learning."""
+        train_params = gaussian_training_data
+
+        config = TransformerConfig(
+            latent_dim=32,
+            n_encoder=1,
+            n_heads=1,
+            n_ff=1,  # Number of feed forward layers
+            label_dim=2
+        )
+
+        rngs = nnx.Rngs(
+            params=jax.random.PRNGKey(0),
+            dropout=jax.random.PRNGKey(1),
+        )
+
+        transformer = Transformer(
+            config=config,
+            tokens=train_params,
+            rngs=rngs,
+        )
+
+        base_dist = NormalDistribution(rngs=rngs)
+
+        return TFMPE(
+            vf_network=transformer,
+            base_dist=base_dist,
+            solver=diffrax.Dopri5(),
+            ode_kwargs={'rtol': 1e-5, 'atol': 1e-5},
+        )
+
+    @pytest.mark.slow
+    def test_posterior_samples_are_positive(
+        self,
+        n_dim,
+        gaussian_tfmpe_instance,
+        gaussian_training_data,
+        gaussian_validation_data,
+        labeller
+    ):
+        """Verify samples from posterior have mean≈0, std≈2.
+
+        Given:
+        - Trained TFMPE instance
+        - fit_fast training for 1000 iterations
+
+        When:
+        - Sample 1000 times from posterior
+
+        Then:
+        - Most samples are positive
+        """
+        # Train the model
+        optimizer = optax.adam(learning_rate=1e-3)
+        opt = nnx.Optimizer(
+            gaussian_tfmpe_instance, optimizer, wrt=nnx.Param
+        )
+        rng = jax.random.PRNGKey(42)
+
+        trained_tfmpe, _ = fit_fast(
+            model=gaussian_tfmpe_instance,
+            train=gaussian_training_data,
+            val=gaussian_validation_data,
+            loss=_cfm_loss,
+            opt=opt,
+            n_iter=1000,
+            batch_size=100,
+            rng=rng,
+        )
+
+        # Verify training succeeded
+        assert isinstance(trained_tfmpe, TFMPE)
+
+        # Create batched context and params for vectorized sampling
+        n_samples = 10000
+
+        # Params template: (n_samples, n_dim, 1)
+        tokens, decoder = Tokens.from_pytree_with_decoder(
+            {
+                'y': jnp.zeros((n_samples, 1, 1)),
+                'x': jnp.zeros((n_samples, n_dim, 1)),
+                'c': jnp.zeros((n_samples, 1, 1))
+            },
+            condition=['c'],
+            sample_ndims=1,
+            labeller=labeller
+        )
+
+        # Vmap over samples
+        all_samples = trained_tfmpe.sample_posterior(
+            tokens
+        )
+        # all_samples.data shape: (1000, n_dim, 1)
+
+        # Compute statistics across all dimensions
+        samples_array = decoder(all_samples)['y']
+
+        threshold = .05
+        assert jnp.sum(samples_array < 0 , axis=0) < n_samples * threshold, (
+            "Too many negative samples"
+        )

--- a/test/test_estimators/test_e2e_training.py
+++ b/test/test_estimators/test_e2e_training.py
@@ -12,12 +12,19 @@ import pytest
 from flax import nnx
 
 from tfmpe.estimators.tfmpe import TFMPE, NormalDistribution
-from tfmpe.estimators.training import fit_bottom_up, _cfm_loss
+from tfmpe.estimators.training import fit_bottom_up
+from tfmpe.estimators.training.loss import cfm_loss as _cfm_loss
 from tfmpe.nn.training import fit_fast
 from tfmpe.preprocessing.tokens import Tokens
 from tfmpe.preprocessing.utils import Labeller
 from tfmpe.nn.transformer import Transformer, TransformerConfig
 from jaxtyping import Array
+
+PRECISION_MODES = {
+    "float32": dict(ops_dtype=jnp.float32, sensitive_ops_dtype=jnp.float32),
+    "bfloat16": dict(ops_dtype=jnp.bfloat16, sensitive_ops_dtype=jnp.bfloat16),
+    "mixed": dict(ops_dtype=jnp.bfloat16, sensitive_ops_dtype=jnp.float32),
+}
 
 def create_hierarchical_gaussian_data(
     rng: Array,
@@ -421,20 +428,19 @@ class TestE2ETrainingHalfNormal:
 
         return tokens
 
-    @pytest.fixture
-    def gaussian_tfmpe_instance(
+    def _make_tfmpe(
         self,
-        gaussian_training_data
+        gaussian_training_data,
+        precision_mode="float32",
     ) -> TFMPE:
-        """TFMPE instance for Gaussian learning."""
-        train_params = gaussian_training_data
-
+        """Create TFMPE instance for Gaussian learning."""
         config = TransformerConfig(
             latent_dim=32,
             n_encoder=1,
             n_heads=1,
-            n_ff=1,  # Number of feed forward layers
-            label_dim=2
+            n_ff=1,
+            label_dim=2,
+            **PRECISION_MODES[precision_mode],
         )
 
         rngs = nnx.Rngs(
@@ -444,7 +450,7 @@ class TestE2ETrainingHalfNormal:
 
         transformer = Transformer(
             config=config,
-            tokens=train_params,
+            tokens=gaussian_training_data,
             rngs=rngs,
         )
 
@@ -458,10 +464,11 @@ class TestE2ETrainingHalfNormal:
         )
 
     @pytest.mark.slow
+    @pytest.mark.parametrize("precision_mode", PRECISION_MODES.keys())
     def test_posterior_samples_are_positive(
         self,
         n_dim,
-        gaussian_tfmpe_instance,
+        precision_mode,
         gaussian_training_data,
         gaussian_validation_data,
         labeller
@@ -478,6 +485,10 @@ class TestE2ETrainingHalfNormal:
         Then:
         - Most samples are positive
         """
+        gaussian_tfmpe_instance = self._make_tfmpe(
+            gaussian_training_data, precision_mode
+        )
+
         # Train the model
         optimizer = optax.adam(learning_rate=1e-3)
         opt = nnx.Optimizer(

--- a/test/test_estimators/test_ode.py
+++ b/test/test_estimators/test_ode.py
@@ -1,0 +1,183 @@
+"""Unit tests for ODE solving helpers."""
+
+import jax
+import jax.numpy as jnp
+from jax.scipy.stats import norm
+import pytest
+
+from tfmpe.estimators.ode import (
+    solve_forward_ode,
+    solve_augmented_ode,
+)
+
+from .conftest import create_mock_tokens
+
+class TestSolveForwardODE:
+    """Test forward ODE solver with doubling flow."""
+
+    @pytest.mark.parametrize(
+        "n_tokens,batch_size",
+        [
+            (1, 1),
+            (2, 1),
+            (1, 3),
+            (2, 2),
+        ],
+    )
+    def test_multidim_tokens_shapes(
+        self, doubling_vf, solver, n_tokens, batch_size
+    ):
+        """Test forward ODE with different Tokens shapes.
+
+        Verify that:
+        1. Output shape matches input shape
+        2. Output is doubled (doubling flow: f(x) = log(2)·x)
+        """
+        # Create data with specified shape (n_tokens, batch)
+        data_shape = (n_tokens, batch_size)
+        seed = jax.random.PRNGKey(42)
+        x0_data = jax.random.normal(seed, data_shape)
+
+        # Create mock context and params
+        tokens = create_mock_tokens(
+            jnp.zeros((n_tokens, batch_size)),
+            x0_data
+        )
+
+        # Solve forward ODE
+        result = solve_forward_ode(
+            doubling_vf,
+            tokens,
+            solver,
+        )
+
+        # Check output shape matches input shape
+        assert result.data.shape == tokens.data.shape
+
+        # Check that values are doubled (analytical solution for
+        # doubling flow is 2x)
+        assert jnp.allclose(
+            result.data[result.partition_idx:], 2.0 * x0_data, rtol=0.01
+        )
+
+class TestSolveAugmentedODE:
+    """Test augmented ODE with trace-based log determinant."""
+
+    def test_constant_vf_preserves_density(self, solver):
+        """Test that constant VF (f=0) preserves Gaussian density.
+
+        For constant transform f(x)=0, the flow is identity.
+        Sample density should equal base density N(0,1).
+        """
+        def constant_vf(tok, t):
+            return jnp.zeros_like(tok.data[:, tok.partition_idx:])
+
+        # Create 100 sample Tokens from N(0, 1), n_tokens=1, batch=1
+        seed = jax.random.PRNGKey(42)
+        n_samples = 100
+        samples = jax.random.normal(seed, (n_samples, 1, 1))
+
+        # Compute expected log prob for N(0, 1)
+        expected_log_probs = norm.logpdf(samples[:, 0, 0])
+
+        tokens = create_mock_tokens(
+            jnp.zeros((n_samples, 1, 1)),
+            samples,
+            sample_ndims=1
+        )
+        rngs = jnp.stack(jax.random.split(seed, n_samples))
+
+        params_final_batch, log_det_batch = jax.vmap(
+            lambda tok, rng_: solve_augmented_ode(
+                constant_vf,
+                tok,
+                solver,
+                rng_,
+                rtol=1e-5,
+                atol=1e-5,
+                n_epsilon=20,
+            )
+        )(tokens, rngs)
+
+        # Compute log probs: log_p(z_0) - log_det_jacobian
+        log_p_z0_batch = norm.logpdf(params_final_batch.data[:, tokens.partition_idx, 0])
+        log_probs = log_p_z0_batch - log_det_batch
+
+        # Compare with expected (stricter tolerances)
+        assert jnp.allclose(
+            log_probs,
+            expected_log_probs,
+            rtol=0.05,
+            atol=0.1,
+        )
+
+    def test_doubling_vf_log_prob(self, solver):
+        """Test log prob computation for doubling VF.
+
+        For f(x) = log(2)·x, the flow scales samples by 2.
+        Sample density changes from N(0,1) to N(0,4).
+        """
+        def doubling_vf(tok, t):
+            return jnp.log(2.0) * tok.data[:, tok.partition_idx:]
+
+        # Create 100 sample Tokens from N(0, 1), n_tokens=1, batch=1
+        seed = jax.random.PRNGKey(42)
+        samples = jax.random.normal(seed, (100, 1, 1))
+        n_samples = 100
+        rngs = jnp.stack(jax.random.split(seed, n_samples))
+
+        # Expected log prob for transformed samples at N(0, 2)
+        expected_log_probs = norm.logpdf(samples[:, 0, 0], scale=2.0)
+
+        tokens = create_mock_tokens(
+            jnp.zeros((n_samples, 1, 1)),
+            samples,
+            sample_ndims=1
+        )
+
+        params_final_batch, log_det_batch = jax.vmap(
+            lambda tok, rng_: solve_augmented_ode(
+                doubling_vf,
+                tok,
+                solver,
+                rng_,
+                rtol=1e-5,
+                atol=1e-5,
+                n_epsilon=30,
+            )
+        )(tokens, rngs)
+
+        # Compute log probs: log_p(z_0) - log_det_jacobian
+        log_p_z0_batch = norm.logpdf(params_final_batch.data[:, tokens.partition_idx, 0])
+        log_probs = log_p_z0_batch - log_det_batch
+
+        # Compare with expected (stochastic trace estimation is noisy)
+        # Max relative error ~34% due to trace estimation variance
+        assert jnp.allclose(
+            log_probs,
+            expected_log_probs,
+            rtol=0.2,
+            atol=0.3,
+        )
+
+    def test_augmented_state_shape(self, solver):
+        """Test that augmented ODE returns correct output shape."""
+        def vf(tok, t):
+            return -tok.data[:, tok.partition_idx:]  # Simple decay
+
+        x0_data = jnp.array([[1.0, 2.0, 3.0]])
+        tokens = create_mock_tokens(
+            jnp.zeros((1, 1)),
+            x0_data
+        )
+        rng = jax.random.PRNGKey(0)
+
+        params_final, log_det = solve_augmented_ode(
+            vf,
+            tokens,
+            solver,
+            rng,
+        )
+
+        assert params_final.data.shape == tokens.data.shape
+        assert log_det.shape == ()  # Scalar

--- a/test/test_estimators/test_pf_training.py
+++ b/test/test_estimators/test_pf_training.py
@@ -70,6 +70,7 @@ class TestFitPF:
 
         config = TransformerConfig(
             latent_dim=16, n_encoder=1, n_heads=1, n_ff=2,
+            attention='softmax',
         )
         rngs = nnx.Rngs(params=jax.random.PRNGKey(0), dropout=jax.random.PRNGKey(1))
         transformer = Transformer(config=config, tokens=tokens, rngs=rngs)

--- a/test/test_estimators/test_pf_training.py
+++ b/test/test_estimators/test_pf_training.py
@@ -1,0 +1,119 @@
+"""Smoke test for fit_pf posterior factorised training."""
+
+import diffrax
+import jax
+import jax.numpy as jnp
+import optax
+import pytest
+from flax import nnx
+
+from tfmpe.estimators.tfmpe import TFMPE, NormalDistribution
+from tfmpe.estimators.training import fit_pf, _cfm_loss
+from tfmpe.preprocessing.tokens import Tokens
+from tfmpe.preprocessing.utils import Labeller
+from tfmpe.nn.transformer import Transformer, TransformerConfig
+
+
+class TestFitPF:
+    n_groups: int = 2
+    n_obs: int = 2
+
+    @pytest.fixture
+    def prior_fn(self):
+        def _prior_fn(rng, n, n_samples=10, *args):
+            k1, k2 = jax.random.split(rng)
+            sigma = jnp.abs(jax.random.normal(k1, (n_samples,))) + 0.1
+            sigma = sigma[:, None, None]
+            mu = jax.random.normal(k2, (n_samples, n))
+            mu = mu[..., None]
+            return {'sigma': sigma, 'mu': mu}
+        return _prior_fn
+
+    @pytest.fixture
+    def simulator_fn(self):
+        def _simulator_fn(rng, params_dict, n, *args):
+            sigma = params_dict['sigma']
+            mu = params_dict['mu']
+            n_samples = sigma.shape[0]
+            rng, key = jax.random.split(rng)
+            noise = jax.random.normal(key, (n_samples, n, self.n_obs))
+            y = noise * sigma + mu
+            y = y[..., None]
+            return {'y': y}
+        return _simulator_fn
+
+    @pytest.fixture
+    def local_fn(self):
+        def _local_fn(rng, global_samples, n, *args):
+            n_samples = global_samples['sigma'].shape[0]
+            mu = jax.random.normal(rng, (n_samples, n, 1))
+            return {'mu': mu}
+        return _local_fn
+
+    @pytest.fixture
+    def labeller(self):
+        return Labeller.for_keys(['sigma', 'mu', 'y'])
+
+    def _make_tfmpe(self, prior_fn, simulator_fn, labeller, n_groups):
+        rng = jax.random.PRNGKey(0)
+        rng, key = jax.random.split(rng)
+        params = prior_fn(key, n=n_groups, n_samples=10)
+        rng, key = jax.random.split(rng)
+        y = simulator_fn(key, params, n=n_groups)
+
+        tokens = Tokens.from_pytree(
+            {**params, **y},
+            condition=list(y.keys()),
+            sample_ndims=1,
+            labeller=labeller,
+        )
+
+        config = TransformerConfig(
+            latent_dim=16, n_encoder=1, n_heads=1, n_ff=2,
+        )
+        rngs = nnx.Rngs(params=jax.random.PRNGKey(0), dropout=jax.random.PRNGKey(1))
+        transformer = Transformer(config=config, tokens=tokens, rngs=rngs)
+        base_dist = NormalDistribution(rngs=rngs)
+        return TFMPE(vf_network=transformer, base_dist=base_dist, solver=diffrax.Dopri5())
+
+    def test_fit_pf_runs(self, prior_fn, simulator_fn, local_fn, labeller):
+        """fit_pf completes without errors and returns expected shapes."""
+        # Global estimator sees y -> theta_g (sigma)
+        # Need to build with varying n_groups tokens shape (use max)
+        tfmpe_global = self._make_tfmpe(prior_fn, simulator_fn, labeller, self.n_groups)
+
+        # Local estimator sees (y_single, theta_g) -> theta_l (mu)
+        # Build with n=1 shape
+        tfmpe_local = self._make_tfmpe(prior_fn, simulator_fn, labeller, 1)
+
+        opt_global = nnx.Optimizer(tfmpe_global, optax.adam(1e-3), wrt=nnx.Param)
+        opt_local = nnx.Optimizer(tfmpe_local, optax.adam(1e-3), wrt=nnx.Param)
+
+        rng = jax.random.PRNGKey(42)
+
+        trained_global, trained_local, losses = fit_pf(
+            tfmpe_global=tfmpe_global,
+            tfmpe_local=tfmpe_local,
+            simulator_fn=simulator_fn,
+            prior_fn=prior_fn,
+            local_fn=local_fn,
+            global_names=['sigma'],
+            n_groups=self.n_groups,
+            n_samples=100,
+            n_val_samples=20,
+            opt_global=opt_global,
+            opt_local=opt_local,
+            n_iter=5,
+            batch_size=20,
+            rng=rng,
+            labeller=labeller,
+        )
+
+        assert isinstance(trained_global, TFMPE)
+        assert isinstance(trained_local, TFMPE)
+
+        (global_train, global_val), (local_train, local_val) = losses
+        assert jnp.all(jnp.isfinite(global_train))
+        assert jnp.all(jnp.isfinite(global_val))
+        assert jnp.all(jnp.isfinite(local_train))
+        assert jnp.all(jnp.isfinite(local_val))

--- a/test/test_estimators/test_pf_training.py
+++ b/test/test_estimators/test_pf_training.py
@@ -8,7 +8,7 @@ import pytest
 from flax import nnx
 
 from tfmpe.estimators.tfmpe import TFMPE, NormalDistribution
-from tfmpe.estimators.training import fit_pf, _cfm_loss
+from tfmpe.estimators.training import fit_pf
 from tfmpe.preprocessing.tokens import Tokens
 from tfmpe.preprocessing.utils import Labeller
 from tfmpe.nn.transformer import Transformer, TransformerConfig

--- a/test/test_estimators/test_tfmpe.py
+++ b/test/test_estimators/test_tfmpe.py
@@ -233,6 +233,163 @@ class TestTFMPESampling:
         assert samples.data.shape == (1, 2 * n_tokens, batch_size)
         assert jnp.all(jnp.isfinite(samples.data))
 
+
+class TestTFMPEBatchedSampling:
+    """Test TFMPE batched sampling via nnx.scan."""
+
+    @pytest.fixture
+    def identity_vf(self):
+        """Identity vector field (f=0)."""
+        def vf(tokens, t):
+            return jnp.zeros_like(tokens.data[:, tokens.partition_idx:])
+        return vf
+
+    @pytest.fixture
+    def tfmpe_identity(self, identity_vf, solver):
+        """TFMPE with identity vector field."""
+        rngs = nnx.Rngs(params=jax.random.PRNGKey(0))
+        return TFMPE(
+            vf_network=identity_vf,
+            base_dist=NormalDistribution(rngs=rngs),
+            solver=solver,
+            ode_kwargs={'rtol': 1e-5, 'atol': 1e-5},
+        )
+
+    def test_batched_returns_correct_shape(
+        self, tfmpe_identity
+    ):
+        """Test sample_posterior_batched returns correct shape.
+
+        Given:
+        - 4 samples, batch_size=2
+
+        Then:
+        - Output shape matches input shape
+        - All values are finite
+        """
+        tokens = create_mock_tokens(
+            jnp.zeros((4, 2, 1)),
+            jnp.zeros((4, 2, 1)),
+            sample_ndims=1,
+        )
+
+        samples = tfmpe_identity.sample_posterior_batched(
+            tokens, batch_size=2
+        )
+
+        assert isinstance(samples, type(tokens))
+        assert samples.data.shape == tokens.data.shape
+        assert jnp.all(jnp.isfinite(samples.data))
+
+    def test_batched_preserves_token_metadata(
+        self, tfmpe_identity
+    ):
+        """Test that batched sampling preserves Token metadata.
+
+        Then:
+        - Labels match input labels
+        """
+        tokens = create_mock_tokens(
+            jnp.zeros((4, 2, 1)),
+            jnp.zeros((4, 2, 1)),
+            sample_ndims=1,
+        )
+
+        samples = tfmpe_identity.sample_posterior_batched(
+            tokens, batch_size=2
+        )
+
+        assert jnp.array_equal(samples.labels, tokens.labels)
+
+    def test_batched_with_padding(
+        self, tfmpe_identity
+    ):
+        """Test batched sampling when target is not divisible by batch_size.
+
+        Given:
+        - 5 samples, batch_size=2 (requires padding)
+
+        Then:
+        - Output has correct shape (trimmed to original size)
+        - All values are finite
+        """
+        tokens = create_mock_tokens(
+            jnp.zeros((5, 2, 1)),
+            jnp.zeros((5, 2, 1)),
+            sample_ndims=1,
+        )
+
+        samples = tfmpe_identity.sample_posterior_batched(
+            tokens, batch_size=2
+        )
+
+        assert samples.data.shape == tokens.data.shape
+        assert jnp.all(jnp.isfinite(samples.data))
+
+    def test_batched_deterministic_with_same_seed(
+        self, tfmpe_identity
+    ):
+        """Test batched sampling is deterministic with same RNG seed.
+
+        Given:
+        - TFMPE with identity VF (f=0)
+
+        When:
+        - Call sample_posterior_batched twice with reseeded RNG
+
+        Then:
+        - Results are identical
+        """
+        tokens = create_mock_tokens(
+            jnp.zeros((4, 1, 1)),
+            jnp.zeros((4, 1, 1)),
+            sample_ndims=1,
+        )
+
+        nnx.reseed(tfmpe_identity, params=42)
+        samples1 = tfmpe_identity.sample_posterior_batched(
+            tokens, batch_size=2
+        )
+        nnx.reseed(tfmpe_identity, params=42)
+        samples2 = tfmpe_identity.sample_posterior_batched(
+            tokens, batch_size=2
+        )
+
+        assert jnp.allclose(samples1.data, samples2.data)
+
+    @pytest.mark.parametrize(
+        "n_samples,batch_size",
+        [
+            (1, 1),
+            (4, 2),
+            (4, 4),
+            (5, 2),
+            (7, 3),
+        ],
+    )
+    def test_batched_various_sizes(
+        self, tfmpe_identity, n_samples, batch_size
+    ):
+        """Test batched sampling with various sample/batch size combos.
+
+        Then:
+        - Output shape matches input
+        - All values finite
+        """
+        tokens = create_mock_tokens(
+            jnp.zeros((n_samples, 2, 1)),
+            jnp.zeros((n_samples, 2, 1)),
+            sample_ndims=1,
+        )
+
+        samples = tfmpe_identity.sample_posterior_batched(
+            tokens, batch_size=batch_size
+        )
+
+        assert samples.data.shape == tokens.data.shape
+        assert jnp.all(jnp.isfinite(samples.data))
+
+
 class TestTFMPELogProb:
     """Test TFMPE log probability computation."""
 

--- a/test/test_estimators/test_tfmpe.py
+++ b/test/test_estimators/test_tfmpe.py
@@ -1,0 +1,472 @@
+"""Integration tests for TFMPE class."""
+
+import jax
+import jax.numpy as jnp
+import pytest
+from flax import nnx
+
+from tfmpe.estimators.tfmpe import TFMPE, NormalDistribution
+from .conftest import create_mock_tokens
+
+class TestTFMPESampling:
+    """Test TFMPE sampling functionality."""
+
+    @pytest.fixture
+    def identity_vf(self):
+        """Identity vector field for testing.
+
+        f(context, params, t) = 0 (no change to state)
+        """
+        def vf(tokens, t):
+            return jnp.zeros_like(tokens.data[:, tokens.partition_idx:])
+        return vf
+
+    @pytest.fixture
+    def tfmpe_identity(self, identity_vf, solver):
+        """TFMPE with identity vector field."""
+        rngs = nnx.Rngs(params=jax.random.PRNGKey(0))
+        return TFMPE(
+            vf_network=identity_vf,
+            base_dist=NormalDistribution(rngs=rngs),
+            solver=solver,
+            ode_kwargs={'rtol': 1e-5, 'atol': 1e-5},
+        )
+
+    def test_sample_posterior_single_sample(
+        self, tfmpe_identity
+    ):
+        """Test sample_posterior returns correct shape.
+
+        Given:
+        - TFMPE instance
+        - Context Token with (n_tokens=2, batch_size=1)
+        - Params Token template with same structure
+        - Single sample (one PRNG key)
+
+        When:
+        - Call sample_posterior()
+
+        Then:
+        - Output shape matches params shape
+        - All values are finite
+        """
+        tokens = create_mock_tokens(
+            jnp.zeros((1, 2, 1)),
+            jnp.zeros((1, 2, 1)),
+            sample_ndims=1
+        )
+
+        samples = tfmpe_identity.sample_posterior(tokens)
+
+        # Check output is Tokens
+        assert isinstance(samples, type(tokens))
+
+        # Check shape matches input (single sample)
+        assert samples.data.shape == tokens.data.shape
+
+        # Check all values are finite
+        assert jnp.all(jnp.isfinite(samples.data))
+
+    def test_sample_posterior_batch_params(
+        self,
+        identity_vf,
+        solver
+    ):
+        """Test sample_posterior returns correct shape with batched parameters
+
+        When:
+        - Call sample_posterior()
+
+        Then:
+        - Output shape matches params shape
+        - All values are finite
+        - Vector function receives correct unbatched shapes
+        """
+        # Create spy wrapper to capture function call shapes
+        call_logs = []
+
+        def spy_vf(tokens, time):
+            call_logs.append({
+                'tokens_shape': tokens.data.shape
+            })
+            return identity_vf(tokens, time)
+
+        # Create TFMPE with spied vector field
+        rngs = nnx.Rngs(params=jax.random.PRNGKey(0))
+        tfmpe = TFMPE(
+            vf_network=spy_vf,
+            base_dist=NormalDistribution(rngs=rngs),
+            solver=solver,
+            ode_kwargs={'rtol': 1e-5, 'atol': 1e-5},
+        )
+
+        n_batch = 10
+        tokens = create_mock_tokens(
+            jnp.zeros((n_batch, 2, 1)),
+            jnp.zeros((n_batch, 2, 1))
+        )
+
+        samples = tfmpe.sample_posterior(
+            tokens
+        )
+
+        # Check output is Tokens
+        assert isinstance(samples, type(tokens))
+
+        # Check shape matches input
+        assert samples.data.shape == tokens.data.shape
+
+        # Check all values are finite
+        assert jnp.all(jnp.isfinite(samples.data))
+        # Check all values are different
+        assert jnp.all(samples.data[0:1, samples.partition_idx:] != samples.data[1:, samples.partition_idx:])
+
+        # Verify spy captured correct shapes
+        assert len(call_logs) > 0, "VF was never called"
+        assert call_logs[0]['tokens_shape'] == (1, 1)
+
+    def test_sample_posterior_preserves_token_metadata(
+        self, tfmpe_identity
+    ):
+        """Test that sample_posterior preserves Token metadata.
+
+        Given:
+        - TFMPE instance
+        - Context Token with specific metadata
+        - Params Token template
+
+        When:
+        - Call sample_posterior()
+
+        Then:
+        - Labels match params labels
+        - Self-attention mask matches params
+        - Slices metadata is preserved
+        """
+        tokens = create_mock_tokens(
+            jnp.zeros((1, 2, 1)),
+            jnp.zeros((1, 2, 1)),
+        )
+
+        samples = tfmpe_identity.sample_posterior(tokens)
+
+        # Check labels preserved
+        assert jnp.array_equal(
+            samples.labels, tokens.labels
+        )
+
+    def test_sample_posterior_with_identity_flow(
+        self, tfmpe_identity
+    ):
+        """Test sample_posterior with identity vector field.
+
+        With identity VF (f=0), samples should match base
+        distribution (no transformation).
+
+        Given:
+        - TFMPE with f(x,c,t)=0
+        - Params Token template
+
+        When:
+        - Call sample_posterior() twice with reseeded RNG
+
+        Then:
+        - Samples are deterministic (same RNG seed gives same
+          result)
+        """
+        tokens = create_mock_tokens(
+            jnp.zeros((1, 1, 1)),
+            jnp.zeros((1, 1, 1))
+        )
+
+        # Sample twice with same RNG seed
+        nnx.reseed(tfmpe_identity, params=42)
+        samples1 = tfmpe_identity.sample_posterior(
+            tokens
+        )
+        nnx.reseed(tfmpe_identity, params=42)
+        samples2 = tfmpe_identity.sample_posterior(
+            tokens
+        )
+
+        # Should be identical (deterministic)
+        assert jnp.allclose(samples1.data, samples2.data)
+
+    @pytest.mark.parametrize(
+        "n_tokens,batch_size",
+        [
+            (1, 1),
+            (2, 1),
+            (1, 3),
+            (2, 2),
+            (3, 5),
+        ],
+    )
+    def test_sampling_various_token_shapes(
+        self, tfmpe_identity, n_tokens, batch_size
+    ):
+        """Test sample_posterior with various token shapes.
+
+        Given:
+        - TFMPE instance
+        - Different (n_tokens, batch_size) combinations
+        - Params Token template
+
+        When:
+        - Call sample_posterior()
+
+        Then:
+        - Output shape matches params shape
+        - All values finite
+        """
+        tokens = create_mock_tokens(
+            jnp.zeros((1, n_tokens, batch_size)),
+            jnp.zeros((1, n_tokens, batch_size)),
+            sample_ndims = 1
+        )
+
+        samples = tfmpe_identity.sample_posterior(tokens)
+
+        assert samples.data.shape == (1, 2 * n_tokens, batch_size)
+        assert jnp.all(jnp.isfinite(samples.data))
+
+class TestTFMPELogProb:
+    """Test TFMPE log probability computation."""
+
+    @pytest.fixture
+    def identity_vf(self):
+        """Identity vector field."""
+        def vf(tokens, t):
+            return jnp.zeros_like(tokens.data[:, tokens.partition_idx:])
+        return vf
+
+    @pytest.fixture
+    def tfmpe_identity(self, identity_vf, solver):
+        """TFMPE with identity vector field."""
+        rngs = nnx.Rngs(params=jax.random.PRNGKey(0))
+        return TFMPE(
+            vf_network=identity_vf,
+            base_dist=NormalDistribution(rngs=rngs),
+            solver=solver,
+            ode_kwargs={'rtol': 1e-5, 'atol': 1e-5},
+        )
+
+    def test_log_prob_returns_scalar(
+        self, tfmpe_identity
+    ):
+        """Test that log_prob_posterior_samples returns scalar.
+
+        Given:
+        - TFMPE instance
+        - Single posterior sample Token (n_tokens=1,
+          batch_size=1)
+
+        When:
+        - Call log_prob_posterior_samples()
+
+        Then:
+        - Output is a scalar (shape ())
+        - Value is finite
+        """
+        tokens = create_mock_tokens(
+            jnp.zeros((1, 1, 1)),
+            jnp.zeros((1, 1, 1)),
+            sample_ndims=1
+        )
+
+        log_prob = tfmpe_identity.log_prob_posterior_samples(
+            tokens
+        )
+
+        # Check output is scalar
+        assert log_prob.shape == (1,)
+
+        # Check value is finite
+        assert jnp.isfinite(log_prob)
+
+    @pytest.mark.parametrize(
+        "n_tokens,batch_size",
+        [
+            (1, 1),
+            (2, 1),
+            (1, 3),
+            (2, 2),
+            (3, 5),
+        ],
+    )
+    def test_log_prob_various_token_shapes(
+        self, tfmpe_identity, n_tokens, batch_size
+    ):
+        """Test log_prob_posterior_samples with various shapes.
+
+        Given:
+        - TFMPE instance
+        - Different (n_tokens, batch_size) combinations
+
+        When:
+        - Call log_prob_posterior_samples()
+
+        Then:
+        - Output is always a scalar
+        - Value is finite
+        """
+        tokens = create_mock_tokens(
+            jnp.zeros((1, n_tokens, batch_size)),
+            jax.random.normal(
+                jax.random.PRNGKey(42), (1, n_tokens, batch_size)
+            ),
+            sample_ndims=1
+        )
+
+        log_prob = tfmpe_identity.log_prob_posterior_samples(
+            tokens
+        )
+
+        # Always returns scalar
+        assert log_prob.shape == (1,)
+        assert jnp.isfinite(log_prob)
+
+
+class TestTFMPEInitialization:
+    """Test TFMPE initialization and configuration."""
+
+    def test_tfmpe_initialization(self, solver):
+        """Test TFMPE can be initialized.
+
+        Given:
+        - Vector field function
+        - Base distribution module
+        - ODE solver
+
+        When:
+        - Create TFMPE instance
+
+        Then:
+        - Instance created successfully
+        - Attributes set correctly
+        """
+        def vf(tokens, time):
+            return jnp.zeros_like(tokens.data[tokens.partition_idx:])
+
+        rngs = nnx.Rngs(params=jax.random.PRNGKey(0))
+        tfmpe = TFMPE(
+            vf_network=vf,
+            base_dist=NormalDistribution(rngs=rngs),
+            solver=solver,
+            ode_kwargs={'rtol': 1e-5, 'atol': 1e-5},
+        )
+
+        assert tfmpe.vf_network is not None
+        assert tfmpe.base_dist is not None
+        assert tfmpe.solver is not None
+
+    def test_tfmpe_with_custom_ode_kwargs(self, solver):
+        """Test TFMPE with custom ODE kwargs.
+
+        Given:
+        - Custom rtol and atol values
+
+        When:
+        - Create TFMPE with custom kwargs
+
+        Then:
+        - ODE kwargs stored correctly
+        """
+        def vf(tokens, time):
+            return jnp.zeros_like(tokens.data[tokens.partition_idx:])
+
+        rngs = nnx.Rngs(params=jax.random.PRNGKey(0))
+        custom_kwargs = {'rtol': 1e-3, 'atol': 1e-4}
+        tfmpe = TFMPE(
+            vf_network=vf,
+            base_dist=NormalDistribution(rngs=rngs),
+            solver=solver,
+            ode_kwargs=custom_kwargs,
+        )
+
+        assert tfmpe.ode_kwargs == custom_kwargs
+
+
+class TestPosteriorSamplingBenchmark:
+    """Benchmark posterior sampling performance with realistic
+    scales."""
+
+    @pytest.fixture
+    def tfmpe_with_transformer(self, solver):
+        """TFMPE instance with Transformer vector field.
+
+        Uses a lightweight transformer config suitable for
+        benchmarking across varying token/batch sizes.
+        """
+        from tfmpe.preprocessing.tokens import Tokens
+        from tfmpe.nn.transformer import (
+            Transformer, TransformerConfig
+        )
+
+        # Create minimal template tokens
+        params_dict = {'x': jnp.ones((1, 1, 1)) * 0.5}
+        params_tokens = Tokens.from_pytree(
+            params_dict,
+            condition=[],
+            sample_ndims=1
+        )
+
+        # Create lightweight transformer
+        config = TransformerConfig(
+            latent_dim=16,
+            n_encoder=1,
+            n_heads=1,
+            n_ff=2,
+        )
+        rngs = nnx.Rngs(
+            params=jax.random.PRNGKey(0),
+            dropout=jax.random.PRNGKey(1),
+        )
+        transformer = Transformer(
+            config=config, tokens=params_tokens, rngs=rngs
+        )
+        base_dist = NormalDistribution(rngs=rngs)
+        tfmpe = TFMPE(
+            vf_network=transformer,
+            base_dist=base_dist,
+            solver=solver,
+        )
+        tfmpe.eval()
+
+        return tfmpe
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("n_tokens", [1, 10, 20, 50])
+    @pytest.mark.parametrize("sample_size", [1, 100, 1000])
+    def test_sample_posterior_benchmark(
+        self, tfmpe_with_transformer, n_tokens, sample_size,
+        benchmark
+    ):
+        """Benchmark sample_posterior across token/batch sizes.
+
+        Measures wall-clock time for sampling from posterior with
+        varying token lengths and batch sizes to understand scaling
+        dynamics.
+
+        Parameters
+        ----------
+        n_tokens : int
+            Number of tokens in the sequence
+        batch_size : int
+            Number of samples in the batch
+        benchmark : pytest_benchmark.fixture
+            Benchmark fixture for timing
+        """
+        # Create tokens of specified shape
+        tokens = create_mock_tokens(
+            jnp.zeros((sample_size, n_tokens, 1)),
+            jnp.zeros((sample_size, n_tokens, 1))
+        )
+
+        # Benchmark the sampling operation
+        def sample():
+            return tfmpe_with_transformer.sample_posterior(
+                tokens
+            )
+
+        benchmark(sample)

--- a/test/test_estimators/test_tfmpe.py
+++ b/test/test_estimators/test_tfmpe.py
@@ -1,10 +1,13 @@
 """Integration tests for TFMPE class."""
 
+import diffrax
 import jax
 import jax.numpy as jnp
 import pytest
 from flax import nnx
 
+from tfmpe.nn.transformer import Transformer, TransformerConfig
+from tfmpe.preprocessing.tokens import Tokens
 from tfmpe.estimators.tfmpe import TFMPE, NormalDistribution
 from .conftest import create_mock_tokens
 
@@ -398,11 +401,6 @@ class TestPosteriorSamplingBenchmark:
         Uses a lightweight transformer config suitable for
         benchmarking across varying token/batch sizes.
         """
-        from tfmpe.preprocessing.tokens import Tokens
-        from tfmpe.nn.transformer import (
-            Transformer, TransformerConfig
-        )
-
         # Create minimal template tokens
         params_dict = {'x': jnp.ones((1, 1, 1)) * 0.5}
         params_tokens = Tokens.from_pytree(
@@ -468,5 +466,107 @@ class TestPosteriorSamplingBenchmark:
             return tfmpe_with_transformer.sample_posterior(
                 tokens
             )
+
+        benchmark(sample)
+
+
+class TestPosteriorSamplingScaling:
+    """Benchmark attention type and solver impact on posterior
+    sampling at realistic hierarchical scales.
+
+    Simulates SIR-like token structure:
+    - 1 global param token
+    - n_l local param tokens (1 per site)
+    - n_obs_per_site * n_l observation tokens
+    """
+
+    @staticmethod
+    def _make_tfmpe(attention, solver):
+        params_dict = {'x': jnp.ones((1, 1, 1)) * 0.5}
+        template = Tokens.from_pytree(
+            params_dict, condition=[], sample_ndims=1
+        )
+
+        config = TransformerConfig(
+            latent_dim=64,
+            n_encoder=2,
+            n_heads=16,
+            n_ff=2,
+            attention=attention,
+        )
+        rngs = nnx.Rngs(
+            params=jax.random.PRNGKey(0),
+            dropout=jax.random.PRNGKey(1),
+        )
+        transformer = Transformer(
+            config=config, tokens=template, rngs=rngs
+        )
+        base_dist = NormalDistribution(rngs=rngs)
+        tfmpe = TFMPE(
+            vf_network=transformer,
+            base_dist=base_dist,
+            solver=solver,
+        )
+        tfmpe.eval()
+        return tfmpe
+
+    @staticmethod
+    def _make_tokens(n_l, n_obs_per_site, sample_size):
+        n_param_tokens = 1 + n_l
+        n_context_tokens = n_obs_per_site * n_l
+        return create_mock_tokens(
+            jnp.zeros((sample_size, n_context_tokens, 1)),
+            jnp.zeros((sample_size, n_param_tokens, 1)),
+            sample_ndims=1,
+        )
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize(
+        "attention", ["softmax", "linear"]
+    )
+    @pytest.mark.parametrize(
+        "solver_name", ["dopri5", "heun", "euler"]
+    )
+    @pytest.mark.parametrize(
+        "n_l,n_obs_per_site",
+        [
+            (50, 10),    # SIR-like: 551 tokens
+            (1000, 50),  # target scale: 51001 tokens
+        ],
+    )
+    def test_scaling_benchmark(
+        self, attention, solver_name, n_l, n_obs_per_site,
+        benchmark
+    ):
+        """Benchmark attention × solver × scale combinations.
+
+        Measures wall-clock time for 1000 posterior samples across
+        attention types (softmax vs linear), solvers (Dopri5,
+        Heun, Euler), and hierarchical scales (n_l=50, n_l=1000).
+        """
+        solver_map = {
+            "dopri5": diffrax.Dopri5(),
+            "heun": diffrax.Heun(),
+            "euler": diffrax.Euler(),
+        }
+        solver = solver_map[solver_name]
+        sample_size = 1000
+
+        tfmpe = self._make_tfmpe(attention, solver)
+        tokens = self._make_tokens(
+            n_l, n_obs_per_site, sample_size
+        )
+
+        n_total = tokens.data.shape[1]
+        print(
+            f"\n  {attention} | {solver_name} | "
+            f"n_l={n_l} | {n_total} tokens | "
+            f"samples={sample_size}"
+        )
+
+        def sample():
+            result = tfmpe.sample_posterior(tokens)
+            result.data.block_until_ready()
+            return result
 
         benchmark(sample)

--- a/test/test_estimators/test_tfmpe.py
+++ b/test/test_estimators/test_tfmpe.py
@@ -478,10 +478,16 @@ class TestPosteriorSamplingScaling:
     - 1 global param token
     - n_l local param tokens (1 per site)
     - n_obs_per_site * n_l observation tokens
+
+    Note: large-scale cases (e.g. n_l=1000) may OOM on GPUs with
+    limited memory. To fail fast instead of hanging, set:
+        XLA_PYTHON_CLIENT_ALLOCATOR=platform
+    before running these tests.
     """
 
     @staticmethod
-    def _make_tfmpe(attention, solver):
+    def _make_tfmpe(attention, solver, ops_dtype=jnp.float32,
+                    sensitive_ops_dtype=jnp.float32):
         params_dict = {'x': jnp.ones((1, 1, 1)) * 0.5}
         template = Tokens.from_pytree(
             params_dict, condition=[], sample_ndims=1
@@ -493,6 +499,8 @@ class TestPosteriorSamplingScaling:
             n_heads=16,
             n_ff=2,
             attention=attention,
+            ops_dtype=ops_dtype,
+            sensitive_ops_dtype=sensitive_ops_dtype,
         )
         rngs = nnx.Rngs(
             params=jax.random.PRNGKey(0),
@@ -534,16 +542,27 @@ class TestPosteriorSamplingScaling:
             (1000, 50),  # target scale: 51001 tokens
         ],
     )
+    @pytest.mark.parametrize(
+        "dtype_name", ["f32", "mixed", "bf16"]
+    )
     def test_scaling_benchmark(
         self, attention, solver_name, n_l, n_obs_per_site,
-        benchmark
+        dtype_name, benchmark
     ):
-        """Benchmark attention × solver × scale combinations.
+        """Benchmark attention × solver × dtype × scale.
 
         Measures wall-clock time for 1000 posterior samples across
         attention types (softmax vs linear), solvers (Dopri5,
-        Heun, Euler), and hierarchical scales (n_l=50, n_l=1000).
+        Heun, Euler), dtypes (f32, mixed bf16/f32, full bf16),
+        and hierarchical scales (n_l=50, n_l=1000).
         """
+        dtype_map = {
+            "f32": (jnp.float32, jnp.float32),
+            "mixed": (jnp.bfloat16, jnp.float32),
+            "bf16": (jnp.bfloat16, jnp.bfloat16),
+        }
+        ops_dtype, sensitive_ops_dtype = dtype_map[dtype_name]
+
         solver_map = {
             "dopri5": diffrax.Dopri5(),
             "heun": diffrax.Heun(),
@@ -552,14 +571,16 @@ class TestPosteriorSamplingScaling:
         solver = solver_map[solver_name]
         sample_size = 1000
 
-        tfmpe = self._make_tfmpe(attention, solver)
+        tfmpe = self._make_tfmpe(
+            attention, solver, ops_dtype, sensitive_ops_dtype
+        )
         tokens = self._make_tokens(
             n_l, n_obs_per_site, sample_size
         )
 
         n_total = tokens.data.shape[1]
         print(
-            f"\n  {attention} | {solver_name} | "
+            f"\n  {attention} | {solver_name} | {dtype_name} | "
             f"n_l={n_l} | {n_total} tokens | "
             f"samples={sample_size}"
         )

--- a/test/test_metrics/test_lc2st.py
+++ b/test/test_metrics/test_lc2st.py
@@ -1,0 +1,273 @@
+import pytest
+from jax import numpy as jnp, random as jr, tree
+import flax.nnx as nnx
+from tfmpe.metrics.lc2st import (
+    _train_lc2st_classifiers,
+    _evaluate_lc2st
+)
+
+from tfmpe.nn.classifier import (
+    BinaryMLPClassifier,
+    MultiBinaryMLPClassifier,
+    MultiFoldBinaryMLPClassifier,
+)
+
+@pytest.mark.parametrize(
+    "x_dim,theta_dim,n_layers,batch_size,latent_dim",
+    [
+        (8, 4, 1, 4, 16),         # small batch
+        (16, 8, 2, 8, 16),        # larger model and batch
+    ],
+)
+def test_binary_mlp_posterior_space_shape(x_dim, theta_dim, n_layers, batch_size, latent_dim):
+    """
+    Test that BinaryMLPClassifier __call__ accepts (x, theta) concatenated inputs
+    and returns an array of shape matching the input batch dimensions.
+    """
+    # Initialize RNG and model
+    key = jr.PRNGKey(0)
+    model = BinaryMLPClassifier(
+        dim=x_dim + theta_dim,  # Concatenated (x, theta) dimension
+        n_layers=n_layers,
+        activation=nnx.relu,
+        latent_dim=latent_dim,
+        rngs=nnx.Rngs(key),
+    )
+
+    # Generate test inputs
+    key_x, key_theta = jr.split(key)
+    x_shape = (batch_size, x_dim)
+    theta_shape = (batch_size, theta_dim)
+    x = jr.normal(key_x, x_shape)
+    theta = jr.normal(key_theta, theta_shape)
+
+    # Forward pass with u = concatenate([x, theta])
+    u = jnp.concatenate([x, theta], axis=-1)
+    out = model(u)
+
+    # Assertions
+    assert isinstance(out, jnp.ndarray), "Output must be a JAX array"
+    # Expect one output per sample: output.shape == input.shape[:-1]
+    assert out.shape == x.shape[:-1], (
+        f"Expected output shape {x.shape[:-1]}, got {out.shape}"
+    )
+    # Check output dtype is floating-point
+    assert jnp.issubdtype(out.dtype, jnp.floating), (
+        f"Expected floating dtype, got {out.dtype}"
+    )
+
+@pytest.mark.parametrize(
+    "x_dim,theta_dim,d_size,batch_size,latent_dim,n_fold,n_ens",
+    [
+        (8, 4, 100, 10, 16, 1, 1),
+        (16, 8, 200, 20, 16, 10, 3)
+    ],
+)
+def test__train_lc2st_classifiers_updates_params(x_dim, theta_dim, d_size, batch_size, latent_dim, n_fold, n_ens):
+    """
+    Test that _train_lc2st_classifiers runs for 1 epoch and updates both main and null classifier parameters.
+    Uses (x, theta) and (x, theta_q) pairs for Local-Classifier 2 Sample Test.
+    """
+    # Setup
+    key = jr.PRNGKey(42)
+    # Instantiate main classifier for (x, theta) concatenated input
+    main_classifier = MultiFoldBinaryMLPClassifier(
+        dim=x_dim + theta_dim,
+        n_layers=2,
+        n_fold=n_fold,
+        n=n_ens,
+        activation=nnx.relu,
+        latent_dim=latent_dim,
+        rngs=nnx.Rngs(key),
+    )
+    
+    # Instantiate null classifier
+    num_null_classifiers = 3
+    null_classifier = MultiBinaryMLPClassifier(
+        dim=x_dim + theta_dim,
+        n_layers=2,
+        activation=nnx.relu,
+        n=num_null_classifiers,
+        latent_dim=latent_dim,
+        rngs=nnx.Rngs(jr.split(key)[1]),
+    )
+    
+    # Generate calibration data (x, theta, theta_q)
+    key_x, key_theta, key_theta_q = jr.split(key, 3)
+    x = jr.normal(key_x, (d_size, x_dim))
+    theta = jr.normal(key_theta, (d_size, theta_dim))
+    theta_q = jr.normal(key_theta_q, (d_size, theta_dim))
+    d_cal = (x, theta, theta_q)
+
+    # Snapshot initial parameters (deep copy since nnx.state returns live view)
+    initial_main_params = tree.map(jnp.copy, nnx.state(main_classifier))
+    initial_null_params = tree.map(jnp.copy, nnx.state(null_classifier))
+
+    # Train for 1 epoch
+    _train_lc2st_classifiers(
+        rng_key=key,
+        d_cal=d_cal,
+        classifier=main_classifier,
+        null_classifier=null_classifier,
+        num_epochs=1,
+        batch_size=batch_size
+    )
+
+    # Check that main classifier parameters have changed
+    leaves_before = tree.leaves(initial_main_params)
+    leaves_after = tree.leaves(nnx.state(main_classifier))
+    main_params_changed = any(
+        not jnp.allclose(b, a) for b, a in zip(leaves_before, leaves_after)
+    )
+    assert main_params_changed, "Expected main classifier parameters to update after training"
+    
+    # Check that null classifier parameters have changed
+    leaves_before = tree.leaves(initial_null_params)
+    leaves_after = tree.leaves(nnx.state(null_classifier))
+    null_params_changed = any(
+        not jnp.allclose(b, a) for b, a in zip(leaves_before, leaves_after)
+    )
+    assert null_params_changed, "Expected null classifier parameters to update after training"
+
+@pytest.mark.parametrize(
+    "x_dim,theta_dim,n,n_fold,Nv,latent_dim",
+    [
+        (8, 4, 3, 5, 10, 16),
+        (16, 8, 5, 10, 20, 16),
+    ],
+)
+def test_multi_fold_classifier_4d_input_shape(x_dim, theta_dim, n, n_fold, Nv, latent_dim):
+    """
+    Test that MultiBinaryMLPClassifier handles 4D input correctly.
+    When input shape is (Nv, n_classifiers, n_folds, x_dim + theta_dim), output should be 
+    (Nv, n_classifiers).
+    """
+    # Initialize classifier
+    cls = MultiFoldBinaryMLPClassifier(
+        dim=x_dim + theta_dim,
+        n_layers=2,
+        activation=nnx.relu,
+        n=n,
+        n_fold=n_fold,
+        latent_dim=latent_dim,
+        rngs=nnx.Rngs(0)
+    )
+    
+    # Create 3D input: (batch_dim, n_classifiers, n_folds, x_dim + theta_dim)
+    key = jr.PRNGKey(42)
+    u_eval_3d = jr.normal(key, shape=(Nv, n, n_fold, x_dim + theta_dim))
+    
+    # Forward pass
+    prob = cls(u_eval_3d)
+    
+    # Verify output shape is (Nv, n_classifiers)
+    expected_shape = (Nv, n, n_fold)
+    assert prob.shape == expected_shape, (
+        f"Expected output shape {expected_shape}, got {prob.shape}. "
+        f"Input shape was {u_eval_3d.shape}"
+    )
+    
+    # Verify output values are probabilities (between 0 and 1)
+    assert jnp.all(prob >= 0) and jnp.all(prob <= 1), (
+        "Output should be probabilities between 0 and 1"
+    )
+
+
+@pytest.mark.parametrize(
+    "x_dim,theta_dim,n,Nv,latent_dim",
+    [
+        (8, 4, 3, 10, 16),
+        (16, 8, 5, 20, 16),
+    ],
+)
+def test_multi_classifier_3d_input_shape(x_dim, theta_dim, n, Nv, latent_dim):
+    """
+    Test that MultiBinaryMLPClassifier handles 3D input correctly.
+    When input shape is (Nv, n_classifiers, x_dim + theta_dim), output should be 
+    (Nv, n_classifiers).
+    """
+    # Initialize classifier
+    cls = MultiBinaryMLPClassifier(
+        dim=x_dim + theta_dim,
+        n_layers=2,
+        activation=nnx.relu,
+        n=n,
+        latent_dim=latent_dim,
+        rngs=nnx.Rngs(0)
+    )
+    
+    # Create 3D input: (batch_dim, n_classifiers, x_dim + theta_dim)
+    key = jr.PRNGKey(42)
+    u_eval_3d = jr.normal(key, shape=(Nv, n, x_dim + theta_dim))
+    
+    # Forward pass
+    prob = cls(u_eval_3d)
+    
+    # Verify output shape is (Nv, n_classifiers)
+    expected_shape = (Nv, n)
+    assert prob.shape == expected_shape, (
+        f"Expected output shape {expected_shape}, got {prob.shape}. "
+        f"Input shape was {u_eval_3d.shape}"
+    )
+    
+    # Verify output values are probabilities (between 0 and 1)
+    assert jnp.all(prob >= 0) and jnp.all(prob <= 1), (
+        "Output should be probabilities between 0 and 1"
+    )
+
+@pytest.mark.parametrize(
+    "x_dim,theta_dim,Nv,num_null,latent_dim",
+    [
+        (8, 4, 10, 5, 16),
+        (16, 8, 20, 10, 16),
+    ],
+)
+def test__evaluate_lc2st_output(x_dim, theta_dim, Nv, num_null, latent_dim):
+    """
+    Test _evaluate_lc2st returns proper-shaped, positive statistics for untrained classifiers.
+    Uses (x, theta) concatenated inputs for Local-Classifier 2 Sample Test evaluation.
+    """
+    key = jr.PRNGKey(123)
+    
+    # Main classifier for (x, theta) concatenated input
+    key_main = jr.PRNGKey(1)
+    main_clf = MultiFoldBinaryMLPClassifier(
+        dim=x_dim + theta_dim,
+        n_layers=2,
+        activation=nnx.relu,
+        latent_dim=latent_dim,
+        rngs=nnx.Rngs(key_main),
+        n=2,
+        n_fold=2
+    )
+    
+    # Null classifiers for (x, theta) concatenated input
+    null_clf = MultiBinaryMLPClassifier(
+        dim=x_dim + theta_dim,
+        n_layers=2,
+        activation=nnx.relu,
+        n=num_null,
+        latent_dim=latent_dim,
+        rngs=nnx.Rngs(0),
+    )
+    
+    # Generate observation and posterior samples
+    key_obs, key_post = jr.split(key)
+    observation = jr.normal(key_obs, (x_dim,))
+    posterior_samples = jr.normal(key_post, (Nv, theta_dim))
+    
+    # Evaluate
+    null_stats, t_stat = _evaluate_lc2st(
+        observation=observation,
+        posterior_samples=posterior_samples,
+        main_classifier=main_clf,
+        null_classifier=null_clf,
+    )
+
+    # Assertions
+    assert null_stats.shape == (num_null,), f"Expected shape ({num_null},), got {null_stats.shape}"
+    
+    assert t_stat.shape == (), (
+        f"Expected shape (), got {t_stat.shape}"
+    )
+    assert t_stat >= 0, "Expected non-negative values"

--- a/test/test_metrics/test_lc2st_e2e.py
+++ b/test/test_metrics/test_lc2st_e2e.py
@@ -1,0 +1,76 @@
+import pytest
+from jax import numpy as jnp, random as jr
+
+from tfmpe.metrics.lc2st import run_lc2st
+
+pytestmark = pytest.mark.slow
+@pytest.mark.parametrize(
+    "dim,train_size",
+    [
+        (1, 1_000),
+        (10, 1_000),
+        (100, 1_000),
+    ]
+)
+def test_lc2st_on_theoretical_distribution(dim, train_size):
+    key = jr.PRNGKey(0)
+    # Create training data
+    n_obs = 10
+
+    sigma = 1e-1
+
+    # Create calibration data (x, theta, theta_q)
+    key_theta, key_x, key = jr.split(key, 3)
+    theta_cal = jr.normal(key_theta, (train_size, dim))
+    x_cal = jnp.repeat(theta_cal, n_obs, axis=1) + \
+            jr.normal(key_x, (train_size, dim * n_obs)) * sigma
+
+    # Compute theoretical posterior parameters
+    # Prior: p(θ) = N(0, 1), Likelihood: p(y_i|θ) = N(θ, σ²) for n_obs observations
+    # Posterior: p(θ|y) = N(μ_n, τ_n²) where τ_n² = σ²/(σ² + n), μ_n = Σy_i/(σ² + n)
+    sigma_sq = sigma ** 2
+    posterior_var = sigma_sq / (sigma_sq + n_obs)
+    posterior_std = jnp.sqrt(posterior_var)
+
+    # Posterior mean for calibration: sum of observations / (σ² + n)
+    x_cal_reshaped = x_cal.reshape(train_size, dim, n_obs)
+    posterior_mean_cal = x_cal_reshaped.sum(axis=2) / (sigma_sq + n_obs)
+
+    # Good: sample from theoretical posterior
+    key_post_cal, key = jr.split(key)
+    theta_q_good = posterior_mean_cal + jr.normal(key_post_cal, (train_size, dim)) * posterior_std
+
+    # Bad: incorrect sampling (just adds noise to prior samples, ignores observation weighting)
+    key_bad_cal, key = jr.split(key)
+    theta_q_bad = theta_cal + jr.normal(key_bad_cal, (train_size, dim)) * sigma + 1
+
+    # Create calibration dataset (x, theta, theta_q)
+    d_cal_good = (x_cal, theta_cal, theta_q_good)
+    d_cal_bad = (x_cal, theta_cal, theta_q_bad)
+
+    ev_key, key = jr.split(key)
+    theta_truth = jr.normal(ev_key, (dim,))
+    obs_key, key = jr.split(key)
+    observation = jnp.repeat(theta_truth, n_obs) + jr.normal(obs_key, (dim * n_obs,)) * sigma
+
+    # Posterior mean for the observation
+    obs_reshaped = observation.reshape(dim, n_obs)
+    posterior_mean_obs = obs_reshaped.sum(axis=1) / (sigma_sq + n_obs)
+
+    # Good: sample from theoretical posterior
+    key_post_obs, key = jr.split(key)
+    theta_post_good = posterior_mean_obs + \
+            jr.normal(key_post_obs, (train_size, dim)) * posterior_std
+
+    # Bad: incorrect sampling (just adds noise to truth, ignores observation weighting)
+    key_bad_obs, key = jr.split(key)
+    theta_post_bad = theta_truth + jr.normal(key_bad_obs, (train_size, dim)) * sigma + 1
+
+    r_good = run_lc2st(ev_key, d_cal_good, observation, theta_post_good)
+    r_bad = run_lc2st(ev_key, d_cal_bad, observation, theta_post_bad)
+
+    assert r_good.main_stat < r_bad.main_stat
+    # assert r_good.main_stat < r_good.critical_value(0.95)
+    # assert r_bad.main_stat > r_bad.critical_value(0.95)
+    assert r_good.critical_value(.95) < 0.15
+    assert r_bad.critical_value(.95) < 0.15

--- a/test/test_nn/test_mlp.py
+++ b/test/test_nn/test_mlp.py
@@ -1,0 +1,189 @@
+"""Tests for MLP model."""
+
+import diffrax
+import jax
+import jax.numpy as jnp
+import pytest
+from flax import nnx
+
+from tfmpe.nn.mlp import MLP
+from tfmpe.preprocessing import Tokens
+from tfmpe.estimators.tfmpe import TFMPE, NormalDistribution
+
+
+@pytest.fixture
+def simple_tokens() -> Tokens:
+    """Create simple tokens with obs and theta."""
+    data = {
+        'obs': jnp.ones((1, 3, 2)),   # 3 obs tokens, value_dim=2
+        'theta': jnp.ones((1, 2, 2))  # 2 param tokens
+    }
+    return Tokens.from_pytree(data, condition=['obs'], sample_ndims=1)
+
+
+@pytest.fixture
+def mlp(simple_tokens: Tokens) -> MLP:
+    """Create MLP for testing."""
+    rngs = nnx.Rngs(0)
+    return MLP(n_ff=2, latent_dim=32, tokens=simple_tokens, rngs=rngs)
+
+
+class TestMLPScalarTime:
+    """Tests for MLP with scalar time (ODE solver case)."""
+
+    def test_output_shape_scalar_time(
+        self,
+        mlp: MLP,
+        simple_tokens: Tokens,
+    ) -> None:
+        """Test MLP output shape with scalar time.
+
+        Given:
+        - MLP initialized with tokens
+        - Scalar time value (as passed by ODE solver)
+
+        When:
+        - Forward pass through MLP
+
+        Then:
+        - Output shape is (*sample_shape, n_target_tokens, value_dim)
+        - All values are finite
+        """
+        time = jnp.array(0.5)
+        output = mlp(simple_tokens, time)
+
+        # n_target_tokens = 2 (theta), value_dim = 2
+        expected_shape = (1, 2, 2)
+        assert output.shape == expected_shape, (
+            f"Expected shape {expected_shape}, got {output.shape}"
+        )
+        assert jnp.all(jnp.isfinite(output))
+
+
+class TestMLPBatchedTime:
+    """Tests for MLP with batched time."""
+
+    def test_output_shape_batched_time(
+        self,
+        mlp: MLP,
+    ) -> None:
+        """Test MLP output shape with batched samples and time.
+
+        Given:
+        - MLP initialized with tokens
+        - Batched tokens with sample_shape=(4,)
+        - Batched time with shape (4,)
+
+        When:
+        - Forward pass through MLP
+
+        Then:
+        - Output shape is (4, n_target_tokens, value_dim)
+        - All values are finite
+        """
+        batched_data = {
+            'obs': jnp.ones((4, 3, 2)),
+            'theta': jnp.ones((4, 2, 2))
+        }
+        batched_tokens = Tokens.from_pytree(
+            batched_data, condition=['obs'], sample_ndims=1
+        )
+        batched_time = jnp.ones((4,)) * 0.5
+
+        output = mlp(batched_tokens, batched_time)
+
+        expected_shape = (4, 2, 2)
+        assert output.shape == expected_shape, (
+            f"Expected shape {expected_shape}, got {output.shape}"
+        )
+        assert jnp.all(jnp.isfinite(output))
+
+
+class TestMLPIntegration:
+    """Integration tests for MLP with TFMPE.sample_posterior."""
+
+    @pytest.fixture
+    def tokens(self) -> Tokens:
+        """Create tokens for integration test."""
+        data = {
+            'obs': jnp.ones((1, 3, 2)),
+            'theta': jnp.ones((1, 2, 2))
+        }
+        return Tokens.from_pytree(data, condition=['obs'], sample_ndims=1)
+
+    @pytest.fixture
+    def tfmpe_with_mlp(self, tokens: Tokens) -> TFMPE:
+        """TFMPE instance with MLP vector field."""
+        rngs = nnx.Rngs(
+            params=jax.random.PRNGKey(0),
+        )
+        mlp = MLP(n_ff=2, latent_dim=32, tokens=tokens, rngs=rngs)
+        base_dist = NormalDistribution(rngs=rngs)
+
+        tfmpe = TFMPE(
+            vf_network=mlp,
+            base_dist=base_dist,
+            solver=diffrax.Dopri5(),
+            ode_kwargs={'rtol': 1e-3, 'atol': 1e-3},
+        )
+        tfmpe.eval()
+        return tfmpe
+
+    def test_sample_posterior_with_mlp(
+        self,
+        tfmpe_with_mlp: TFMPE,
+        tokens: Tokens,
+    ) -> None:
+        """Test TFMPE.sample_posterior works with MLP vector field.
+
+        Given:
+        - TFMPE instance with MLP as vf_network
+        - Tokens with context (obs) and params (theta)
+
+        When:
+        - Call sample_posterior()
+
+        Then:
+        - Output is a Tokens instance
+        - Output shape matches input shape
+        - All values are finite
+        """
+        samples = tfmpe_with_mlp.sample_posterior(tokens)
+
+        assert isinstance(samples, Tokens)
+        assert samples.data.shape == tokens.data.shape
+        assert jnp.all(jnp.isfinite(samples.data))
+
+    def test_sample_posterior_batched(
+        self,
+        tfmpe_with_mlp: TFMPE,
+    ) -> None:
+        """Test TFMPE.sample_posterior with batched samples using MLP.
+
+        Given:
+        - TFMPE instance with MLP
+        - Batched tokens with sample_shape=(10,)
+
+        When:
+        - Call sample_posterior()
+
+        Then:
+        - Output shape matches input (10, n_tokens, value_dim)
+        - All samples are finite
+        - Samples differ (not deterministic across batch)
+        """
+        batched_data = {
+            'obs': jnp.ones((10, 3, 2)),
+            'theta': jnp.ones((10, 2, 2))
+        }
+        batched_tokens = Tokens.from_pytree(
+            batched_data, condition=['obs'], sample_ndims=1
+        )
+
+        samples = tfmpe_with_mlp.sample_posterior(batched_tokens)
+
+        assert samples.data.shape == batched_tokens.data.shape
+        assert jnp.all(jnp.isfinite(samples.data))
+        # Target data (theta) should differ across batch dimension
+        target_data = samples.data[:, samples.partition_idx:]
+        assert not jnp.allclose(target_data[0], target_data[1])

--- a/test/test_nn/test_training.py
+++ b/test/test_nn/test_training.py
@@ -1,0 +1,297 @@
+import diffrax
+import jax
+import jax.numpy as jnp
+import optax
+import pytest
+from flax import nnx
+
+from tfmpe.estimators.tfmpe import TFMPE, NormalDistribution
+from tfmpe.estimators.training import _cfm_loss
+from tfmpe.nn.training import fit_fast, fit_memory_efficient
+from tfmpe.preprocessing.tokens import Tokens
+from tfmpe.nn.transformer import Transformer, TransformerConfig
+from jaxtyping import Array
+
+def create_hierarchical_gaussian_data(
+    rng: Array,
+    n_groups: int = 10,
+    n_obs: int = 20,
+    n_samples: int = 1,
+) -> Tokens:
+    """Generate hierarchical Gaussian linear model data.
+
+    Parameters
+    ----------
+    rng : PRNGKeyArray
+        Random number generator key
+    n_groups : int
+        Number of groups (local parameters)
+    n_obs : int
+        Number of observations per group
+    n_samples : int
+        Number of samples to generate (batched)
+
+    Returns
+    -------
+    tuple[Tokens, Tokens]
+        (params_tokens, context_tokens) where:
+        - params_tokens contains sigma and mu
+        - context_tokens contains y (observations)
+
+    Model
+    -----
+    sigma ~ HalfNormal(1)
+    mu_i ~ Normal(0, 1) for i in 1..n_groups
+    y_ij ~ Normal(mu_i, sigma) for j in 1..n_obs
+    """
+
+    # Generate sigma (n_samples,)
+    rng, key = jax.random.split(rng)
+    sigma = jnp.abs(jax.random.normal(key, (n_samples,))) + 0.1
+
+    # Generate mu (n_samples, n_groups)
+    rng, key = jax.random.split(rng)
+    mu = jax.random.normal(key, (n_samples, n_groups))
+
+    # Generate y (n_samples, n_groups, n_obs)
+    rng, key = jax.random.split(rng)
+    noise = jax.random.normal(
+        key, (n_samples, n_groups, n_obs)
+    )
+    # Broadcast sigma and mu to match noise shape
+    y = (
+        noise * sigma[:, None, None] +
+        mu[:, :, None]
+    )
+    # Reshape to (n_samples, n_groups * n_obs)
+    y = y.reshape(n_samples, n_groups * n_obs)
+
+    # Create params Token with shape (n_samples, n_tokens, 1)
+    params_dict = {
+        'sigma': sigma[:, None, None],  # (n_samples, 1, 1)
+        'mu': mu[..., None],  # (n_samples, n_groups, 1)
+    }
+    context_dict = {
+        'y': y[..., None],  # (n_samples, n_groups * n_obs, 1)
+    }
+    tokens = Tokens.from_pytree(
+        {
+            **params_dict,
+            **context_dict
+        },
+        condition=['y'],
+        sample_ndims=1,
+    )
+
+    return tokens
+
+@pytest.fixture
+def training_data() -> Tokens:
+    """Hierarchical Gaussian training data (params, context)."""
+    rng = jax.random.PRNGKey(42)
+    return create_hierarchical_gaussian_data(
+        rng=rng,
+        n_groups=10,
+        n_obs=20,
+        n_samples=10,
+    )
+
+@pytest.fixture
+def validation_data() -> Tokens:
+    """Hierarchical Gaussian validation data (params, context)."""
+    rng = jax.random.PRNGKey(100)
+    return create_hierarchical_gaussian_data(
+        rng=rng,
+        n_groups=10,
+        n_obs=20,
+        n_samples=3,
+    )
+
+@pytest.fixture
+def tfmpe_instance(training_data: Tokens) -> TFMPE:
+    """TFMPE with Transformer vector field."""
+    config = TransformerConfig(
+        latent_dim=32,
+        n_encoder=1,
+        n_heads=1,
+        n_ff=1,
+        label_dim=2
+    )
+
+    rngs = nnx.Rngs(
+        params=jax.random.PRNGKey(0),
+        dropout=jax.random.PRNGKey(1),
+    )
+    transformer = Transformer(
+        config=config,
+        tokens=training_data,
+        rngs=rngs,
+    )
+
+    base_dist = NormalDistribution(rngs=rngs)
+
+    return TFMPE(
+        vf_network=transformer,
+        base_dist=base_dist,
+        solver=diffrax.Dopri5(),
+        ode_kwargs={'rtol': 1e-3, 'atol': 1e-3},
+    )
+
+
+class TestE2ETrainingFast:
+    """Test fit_fast() speed-optimized training on E2E problem."""
+
+    @pytest.mark.slow
+    def test_fit_fast_trains_successfully(
+        self, tfmpe_instance: TFMPE, training_data: tuple,
+        validation_data: tuple
+    ) -> None:
+        """Test fit_fast() trains without errors.
+
+        Given:
+        - TFMPE instance
+        - Training data (10 samples)
+        - Validation data (3 samples)
+
+        When:
+        - Call fit_fast() for 5 iterations with batch_size=5
+
+        Then:
+        - Training completes without errors
+        - Returned losses have shape (5, 2)
+        - Both train and val losses are finite
+        """
+        optimizer = optax.adam(learning_rate=1e-3)
+        opt = nnx.Optimizer(tfmpe_instance, optimizer, wrt=nnx.Param)
+        rng = jax.random.PRNGKey(42)
+
+        trained_tfmpe, losses = fit_fast(
+            model=tfmpe_instance,
+            train=training_data,
+            val=validation_data,
+            loss=_cfm_loss,
+            opt=opt,
+            n_iter=5,
+            batch_size=5,
+            rng=rng,
+        )
+
+        # Check losses shape (tuple of train and val losses)
+        assert isinstance(losses, tuple), (
+            f"Expected losses to be tuple, "
+            f"got {type(losses)}"
+        )
+        assert len(losses) == 2, (
+            f"Expected 2 loss arrays, got {len(losses)}"
+        )
+        train_losses, val_losses = losses
+        assert train_losses.shape == (5,), (
+            f"Expected train_losses shape (5,), "
+            f"got {train_losses.shape}"
+        )
+        assert val_losses.shape == (5,), (
+            f"Expected val_losses shape (5,), "
+            f"got {val_losses.shape}"
+        )
+
+        # Check losses are finite
+        assert jnp.all(jnp.isfinite(train_losses)), (
+            "Train losses contain NaN or Inf"
+        )
+        assert jnp.all(jnp.isfinite(val_losses)), (
+            "Val losses contain NaN or Inf"
+        )
+
+        # Check TFMPE instance returned
+        assert isinstance(trained_tfmpe, TFMPE)
+
+    @pytest.mark.slow
+    def test_fit_fast_attains_a_suitably_low_loss(
+        self,
+        tfmpe_instance: TFMPE,
+        training_data: Tokens,
+        validation_data: Tokens
+    ) -> None:
+        """Test fit_fast() trains without errors.
+
+        Given:
+        - TFMPE instance
+        - Training data (10 samples)
+        - Validation data (3 samples)
+
+        When:
+        - Call fit_fast() for 5 iterations with batch_size=5
+
+        Then:
+        - Training completes without errors
+        - Returned losses have shape (5, 2)
+        - Both train and val losses are finite
+        """
+        optimizer = optax.adam(learning_rate=1e-3)
+        opt = nnx.Optimizer(tfmpe_instance, optimizer, wrt=nnx.Param)
+        rng = jax.random.PRNGKey(42)
+        threshold = 1e-1
+
+        _, losses = fit_fast(
+            model=tfmpe_instance,
+            train=training_data,
+            val=validation_data,
+            loss=_cfm_loss,
+            opt=opt,
+            n_iter=1000,
+            batch_size=5,
+            rng=rng,
+        )
+
+        train_losses, val_losses = losses
+        assert train_losses[-1] < threshold
+        assert val_losses[-1] < threshold
+
+class TestE2ETrainingMemoryEfficient:
+    """Test fit_memory_efficient() memory-efficient training."""
+
+    @pytest.mark.slow
+    def test_fit_memory_efficient_trains_successfully(
+        self, tfmpe_instance, training_data, validation_data
+    ):
+        """Test fit_memory_efficient() trains without errors.
+
+        Given:
+        - TFMPE instance
+        - TokenGenerator for batches
+        - Validation data
+
+        When:
+        - Call fit_memory_efficient() for 5 iterations
+
+        Then:
+        - Training completes without errors
+        - Returned losses have shape (5, 2) or fewer
+        - Both train and val losses are finite
+        """
+        optimizer = optax.adam(learning_rate=1e-3)
+        opt = nnx.Optimizer(tfmpe_instance, optimizer, wrt=nnx.Param)
+        rng = jax.random.PRNGKey(42)
+
+        trained_tfmpe, losses = fit_memory_efficient(
+            model=tfmpe_instance,
+            train=training_data,
+            val=validation_data,
+            opt=opt,
+            loss=_cfm_loss,
+            n_iter=5,
+            rng=rng,
+            batch_size=1,
+            patience=10,
+        )
+
+        # Check losses shape
+        assert len(losses) == 2
+        assert losses[0].shape[0] <= 5
+
+        # Check losses are finite
+        assert jnp.all(jnp.isfinite(losses[0])), (
+            "Losses contain NaN or Inf"
+        )
+
+        assert isinstance(trained_tfmpe, TFMPE)

--- a/test/test_nn/test_transformer/conftest.py
+++ b/test/test_nn/test_transformer/conftest.py
@@ -1,0 +1,29 @@
+"""Shared fixtures for transformer tests."""
+
+import jax.numpy as jnp
+import pytest
+
+from tfmpe.preprocessing import Tokens, Labeller
+
+
+@pytest.fixture
+def simple_labeller() -> Labeller:
+    """Labeller for simple hierarchical structure."""
+    return Labeller(label_map={'mu': 0, 'theta': 1, 'obs': 2})
+
+
+@pytest.fixture
+def simple_tokens(simple_labeller: Labeller) -> Tokens:
+    """Create context tokens with mu and obs."""
+    pytree = {
+        'mu': jnp.array([[[1.0]]]),
+        'obs': jnp.array([[[0.1], [0.2]]]),
+        'theta': jnp.array([[[2.0], [3.0]]]),
+    }
+    return Tokens.from_pytree(
+        pytree,
+        labeller=simple_labeller,
+        condition=['obs'],
+        sample_ndims=1,
+        batch_ndims={'mu': 1, 'obs': 1},
+    )

--- a/test/test_nn/test_transformer/test_benchmark.py
+++ b/test/test_nn/test_transformer/test_benchmark.py
@@ -1,14 +1,9 @@
 """Benchmark tests for Transformer memory and speed."""
 
-import time
-
 import jax
 import jax.numpy as jnp
-import numpy as np
 import pytest
 from flax import nnx
-from jaxtyping import Array
-
 from tfmpe.nn.transformer import Transformer
 from tfmpe.nn.transformer.config import TransformerConfig
 from tfmpe.preprocessing import Labeller, Tokens
@@ -44,123 +39,130 @@ def create_benchmark_tokens(batch_size: int, seq_len: int) -> Tokens:
     )
 
 
+BATCH_SIZE = 32
+SEQ_LENS = [10, 50, 100, 200, 500]
+N_WARMUP = 3
+
+
+def _make_transformer(tokens):
+    """Create a Transformer and common inputs for benchmarking."""
+    config = TransformerConfig(
+        latent_dim=128,
+        n_encoder=2,
+        n_heads=4,
+        n_ff=2,
+        label_dim=32,
+    )
+    rngs = nnx.Rngs(0)
+    transformer = Transformer(config=config, tokens=tokens, rngs=rngs)
+    time_input = jnp.ones((BATCH_SIZE,))
+    return transformer, time_input
+
+
 class TestTransformerBenchmark:
     """Memory and speed benchmarks for Transformer forward/backward pass."""
 
+    # ── Timing (pytest-benchmark) ──────────────────────────────
+
     @pytest.mark.slow
-    @pytest.mark.parametrize("seq_len", [10, 50, 100, 200, 500])
-    def test_forward_and_backward_benchmark(self, seq_len: int) -> None:
-        """Benchmark forward and backward pass for varying sequence lengths.
-
-        Parameters
-        ----------
-        seq_len : int
-            Number of parameter tokens
-        """
-        batch_size = 32
-        n_warmup = 3
-        n_runs = 10
-
-        config = TransformerConfig(
-            latent_dim=128,
-            n_encoder=2,
-            n_heads=4,
-            n_ff=2,
-            label_dim=32,
-        )
-
-        tokens = create_benchmark_tokens(batch_size, seq_len)
-        time_input = jnp.ones((batch_size,))
-
-        rngs = nnx.Rngs(0)
-        transformer = Transformer(
-            config=config,
-            tokens=tokens,
-            rngs=rngs,
-        )
+    @pytest.mark.benchmark(group="forward")
+    @pytest.mark.parametrize("seq_len", SEQ_LENS)
+    def test_forward_benchmark(self, benchmark, seq_len: int) -> None:
+        tokens = create_benchmark_tokens(BATCH_SIZE, seq_len)
+        transformer, time_input = _make_transformer(tokens)
 
         @nnx.jit
-        def forward_fn(model: Transformer, tokens: Tokens, t: Array) -> Array:
+        def forward_fn(model, tokens, t):
             return model(tokens=tokens, time=t, deterministic=True)
 
-        def loss_fn(model: Transformer) -> Array:
+        # Pre-compile
+        forward_fn(transformer, tokens, time_input).block_until_ready()
+
+        def run():
+            result = forward_fn(transformer, tokens, time_input)
+            result.block_until_ready()
+            return result
+
+        benchmark.pedantic(run, warmup_rounds=N_WARMUP, rounds=10, iterations=1)
+
+    @pytest.mark.slow
+    @pytest.mark.benchmark(group="backward")
+    @pytest.mark.parametrize("seq_len", SEQ_LENS)
+    def test_backward_benchmark(self, benchmark, seq_len: int) -> None:
+        tokens = create_benchmark_tokens(BATCH_SIZE, seq_len)
+        transformer, time_input = _make_transformer(tokens)
+
+        def loss_fn(model):
             output = model(tokens=tokens, time=time_input, deterministic=True)
             return jnp.mean(output ** 2)
 
         grad_fn = nnx.jit(nnx.value_and_grad(loss_fn))
 
-        # Warmup forward pass
-        for _ in range(n_warmup):
-            result = forward_fn(transformer, tokens, time_input)
-            result.block_until_ready()
+        # Pre-compile
+        loss, _ = grad_fn(transformer)
+        loss.block_until_ready()
 
-        # Get memory stats if available
+        def run():
+            loss, grads = grad_fn(transformer)
+            loss.block_until_ready()
+            return loss
+
+        benchmark.pedantic(run, warmup_rounds=N_WARMUP, rounds=10, iterations=1)
+
+    # ── Memory (hand-rolled) ───────────────────────────────────
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("seq_len", SEQ_LENS)
+    def test_forward_peak_memory(self, seq_len: int) -> None:
         device = jax.local_devices()[0]
-        has_memory_stats = hasattr(device, 'memory_stats')
+        if not hasattr(device, "memory_stats"):
+            pytest.skip("Device does not support memory_stats")
 
-        # Benchmark forward pass
-        if has_memory_stats:
-            _ = device.memory_stats()
+        tokens = create_benchmark_tokens(BATCH_SIZE, seq_len)
+        transformer, time_input = _make_transformer(tokens)
 
-        forward_times = []
-        for _ in range(n_runs):
-            start = time.perf_counter()
-            result = forward_fn(transformer, tokens, time_input)
-            result.block_until_ready()
-            forward_times.append(time.perf_counter() - start)
+        @nnx.jit
+        def forward_fn(model, tokens, t):
+            return model(tokens=tokens, time=t, deterministic=True)
 
-        forward_peak_memory = None
-        if has_memory_stats:
-            stats = device.memory_stats()
-            if stats and 'peak_bytes_in_use' in stats:
-                forward_peak_memory = stats['peak_bytes_in_use'] / (1024 * 1024)
+        # Warmup / compile
+        for _ in range(N_WARMUP):
+            forward_fn(transformer, tokens, time_input).block_until_ready()
 
-        # Warmup backward pass
-        for _ in range(n_warmup):
-            loss, grads = grad_fn(transformer)
+        _ = device.memory_stats()  # reset baseline
+        forward_fn(transformer, tokens, time_input).block_until_ready()
+
+        stats = device.memory_stats()
+        if stats and "peak_bytes_in_use" in stats:
+            peak_mb = stats["peak_bytes_in_use"] / (1024 * 1024)
+            print(f"\nForward peak memory (seq_len={seq_len}): {peak_mb:.2f} MB")
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("seq_len", SEQ_LENS)
+    def test_backward_peak_memory(self, seq_len: int) -> None:
+        device = jax.local_devices()[0]
+        if not hasattr(device, "memory_stats"):
+            pytest.skip("Device does not support memory_stats")
+
+        tokens = create_benchmark_tokens(BATCH_SIZE, seq_len)
+        transformer, time_input = _make_transformer(tokens)
+
+        def loss_fn(model):
+            output = model(tokens=tokens, time=time_input, deterministic=True)
+            return jnp.mean(output ** 2)
+
+        grad_fn = nnx.jit(nnx.value_and_grad(loss_fn))
+
+        # Warmup / compile
+        for _ in range(N_WARMUP):
+            loss, _ = grad_fn(transformer)
             loss.block_until_ready()
 
-        # Reset memory stats before backward benchmark
-        if has_memory_stats:
-            _ = device.memory_stats()
+        _ = device.memory_stats()  # reset baseline
+        loss, _ = grad_fn(transformer)
+        loss.block_until_ready()
 
-        backward_times = []
-        for _ in range(n_runs):
-            start = time.perf_counter()
-            loss, grads = grad_fn(transformer)
-            loss.block_until_ready()
-            backward_times.append(time.perf_counter() - start)
-
-        backward_peak_memory = None
-        if has_memory_stats:
-            stats = device.memory_stats()
-            if stats and 'peak_bytes_in_use' in stats:
-                backward_peak_memory = stats['peak_bytes_in_use'] / (1024 * 1024)
-
-        # Calculate statistics
-        forward_mean = np.mean(forward_times) * 1000
-        forward_std = np.std(forward_times) * 1000
-        backward_mean = np.mean(backward_times) * 1000
-        backward_std = np.std(backward_times) * 1000
-
-        time_ratio = backward_mean / forward_mean if forward_mean > 0 else 0
-
-        # Print results
-        print(f"\n{'=' * 60}")
-        print(f"Benchmark: seq_len={seq_len}, batch_size={batch_size}")
-        print(f"{'=' * 60}")
-        print(f"Forward pass:  {forward_mean:.2f} +/- {forward_std:.2f} ms")
-        if forward_peak_memory is not None:
-            print(f"               Peak memory: {forward_peak_memory:.2f} MB")
-        print(f"Backward pass: {backward_mean:.2f} +/- {backward_std:.2f} ms")
-        if backward_peak_memory is not None:
-            print(f"               Peak memory: {backward_peak_memory:.2f} MB")
-        print(f"Time ratio (backward/forward): {time_ratio:.2f}x")
-        if forward_peak_memory is not None and backward_peak_memory is not None:
-            memory_ratio = backward_peak_memory / forward_peak_memory
-            print(f"Memory ratio (backward/forward): {memory_ratio:.2f}x")
-        print(f"{'=' * 60}")
-
-        # Basic sanity checks
-        assert forward_mean > 0, "Forward pass should take positive time"
-        assert backward_mean > 0, "Backward pass should take positive time"
+        stats = device.memory_stats()
+        if stats and "peak_bytes_in_use" in stats:
+            peak_mb = stats["peak_bytes_in_use"] / (1024 * 1024)
+            print(f"\nBackward peak memory (seq_len={seq_len}): {peak_mb:.2f} MB")

--- a/test/test_nn/test_transformer/test_benchmark.py
+++ b/test/test_nn/test_transformer/test_benchmark.py
@@ -1,0 +1,166 @@
+"""Benchmark tests for Transformer memory and speed."""
+
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from flax import nnx
+from jaxtyping import Array
+
+from tfmpe.nn.transformer import Transformer
+from tfmpe.nn.transformer.config import TransformerConfig
+from tfmpe.preprocessing import Labeller, Tokens
+
+
+def create_benchmark_tokens(batch_size: int, seq_len: int) -> Tokens:
+    """Create tokens for benchmarking.
+
+    Parameters
+    ----------
+    batch_size : int
+        Batch size
+    seq_len : int
+        Number of parameter tokens
+
+    Returns
+    -------
+    Tokens
+        Tokens object for benchmarking
+    """
+    labeller = Labeller(label_map={'context': 0, 'param': 1})
+
+    data = {
+        'context': jnp.ones((batch_size, 2, 1)),
+        'param': jnp.ones((batch_size, seq_len, 1)),
+    }
+
+    return Tokens.from_pytree(
+        data,
+        labeller=labeller,
+        condition=['context'],
+        sample_ndims=1,
+    )
+
+
+class TestTransformerBenchmark:
+    """Memory and speed benchmarks for Transformer forward/backward pass."""
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("seq_len", [10, 50, 100, 200, 500])
+    def test_forward_and_backward_benchmark(self, seq_len: int) -> None:
+        """Benchmark forward and backward pass for varying sequence lengths.
+
+        Parameters
+        ----------
+        seq_len : int
+            Number of parameter tokens
+        """
+        batch_size = 32
+        n_warmup = 3
+        n_runs = 10
+
+        config = TransformerConfig(
+            latent_dim=128,
+            n_encoder=2,
+            n_heads=4,
+            n_ff=2,
+            label_dim=32,
+        )
+
+        tokens = create_benchmark_tokens(batch_size, seq_len)
+        time_input = jnp.ones((batch_size,))
+
+        rngs = nnx.Rngs(0)
+        transformer = Transformer(
+            config=config,
+            tokens=tokens,
+            rngs=rngs,
+        )
+
+        @nnx.jit
+        def forward_fn(model: Transformer, tokens: Tokens, t: Array) -> Array:
+            return model(tokens=tokens, time=t, deterministic=True)
+
+        def loss_fn(model: Transformer) -> Array:
+            output = model(tokens=tokens, time=time_input, deterministic=True)
+            return jnp.mean(output ** 2)
+
+        grad_fn = nnx.jit(nnx.value_and_grad(loss_fn))
+
+        # Warmup forward pass
+        for _ in range(n_warmup):
+            result = forward_fn(transformer, tokens, time_input)
+            result.block_until_ready()
+
+        # Get memory stats if available
+        device = jax.local_devices()[0]
+        has_memory_stats = hasattr(device, 'memory_stats')
+
+        # Benchmark forward pass
+        if has_memory_stats:
+            _ = device.memory_stats()
+
+        forward_times = []
+        for _ in range(n_runs):
+            start = time.perf_counter()
+            result = forward_fn(transformer, tokens, time_input)
+            result.block_until_ready()
+            forward_times.append(time.perf_counter() - start)
+
+        forward_peak_memory = None
+        if has_memory_stats:
+            stats = device.memory_stats()
+            if stats and 'peak_bytes_in_use' in stats:
+                forward_peak_memory = stats['peak_bytes_in_use'] / (1024 * 1024)
+
+        # Warmup backward pass
+        for _ in range(n_warmup):
+            loss, grads = grad_fn(transformer)
+            loss.block_until_ready()
+
+        # Reset memory stats before backward benchmark
+        if has_memory_stats:
+            _ = device.memory_stats()
+
+        backward_times = []
+        for _ in range(n_runs):
+            start = time.perf_counter()
+            loss, grads = grad_fn(transformer)
+            loss.block_until_ready()
+            backward_times.append(time.perf_counter() - start)
+
+        backward_peak_memory = None
+        if has_memory_stats:
+            stats = device.memory_stats()
+            if stats and 'peak_bytes_in_use' in stats:
+                backward_peak_memory = stats['peak_bytes_in_use'] / (1024 * 1024)
+
+        # Calculate statistics
+        forward_mean = np.mean(forward_times) * 1000
+        forward_std = np.std(forward_times) * 1000
+        backward_mean = np.mean(backward_times) * 1000
+        backward_std = np.std(backward_times) * 1000
+
+        time_ratio = backward_mean / forward_mean if forward_mean > 0 else 0
+
+        # Print results
+        print(f"\n{'=' * 60}")
+        print(f"Benchmark: seq_len={seq_len}, batch_size={batch_size}")
+        print(f"{'=' * 60}")
+        print(f"Forward pass:  {forward_mean:.2f} +/- {forward_std:.2f} ms")
+        if forward_peak_memory is not None:
+            print(f"               Peak memory: {forward_peak_memory:.2f} MB")
+        print(f"Backward pass: {backward_mean:.2f} +/- {backward_std:.2f} ms")
+        if backward_peak_memory is not None:
+            print(f"               Peak memory: {backward_peak_memory:.2f} MB")
+        print(f"Time ratio (backward/forward): {time_ratio:.2f}x")
+        if forward_peak_memory is not None and backward_peak_memory is not None:
+            memory_ratio = backward_peak_memory / forward_peak_memory
+            print(f"Memory ratio (backward/forward): {memory_ratio:.2f}x")
+        print(f"{'=' * 60}")
+
+        # Basic sanity checks
+        assert forward_mean > 0, "Forward pass should take positive time"
+        assert backward_mean > 0, "Backward pass should take positive time"

--- a/test/test_nn/test_transformer/test_benchmark.py
+++ b/test/test_nn/test_transformer/test_benchmark.py
@@ -38,8 +38,8 @@ def create_benchmark_tokens(batch_size: int, seq_len: int) -> Tokens:
     )
 
 
-BATCH_SIZE = 32
-SEQ_LENS = [10, 50, 100, 200, 500]
+BATCH_SIZE = 100
+SEQ_LENS = [10, 50, 100, 200, 500, 1_000, 10_000]
 N_WARMUP = 3
 
 PRECISION_MODES = {
@@ -52,11 +52,12 @@ PRECISION_MODES = {
 def _make_transformer(tokens, precision_mode="float32"):
     """Create a Transformer and common inputs for benchmarking."""
     config = TransformerConfig(
-        latent_dim=128,
+        latent_dim=256,
         n_encoder=2,
         n_heads=4,
         n_ff=2,
-        label_dim=32,
+        label_dim=8,
+        attention='cudnn',
         **PRECISION_MODES[precision_mode],
     )
     rngs = nnx.Rngs(0)

--- a/test/test_nn/test_transformer/test_benchmark.py
+++ b/test/test_nn/test_transformer/test_benchmark.py
@@ -8,7 +8,6 @@ from tfmpe.nn.transformer import Transformer
 from tfmpe.nn.transformer.config import TransformerConfig
 from tfmpe.preprocessing import Labeller, Tokens
 
-
 def create_benchmark_tokens(batch_size: int, seq_len: int) -> Tokens:
     """Create tokens for benchmarking.
 

--- a/test/test_nn/test_transformer/test_benchmark.py
+++ b/test/test_nn/test_transformer/test_benchmark.py
@@ -42,8 +42,14 @@ BATCH_SIZE = 32
 SEQ_LENS = [10, 50, 100, 200, 500]
 N_WARMUP = 3
 
+PRECISION_MODES = {
+    "float32": dict(ops_dtype=jnp.float32, sensitive_ops_dtype=jnp.float32),
+    "bfloat16": dict(ops_dtype=jnp.bfloat16, sensitive_ops_dtype=jnp.bfloat16),
+    "mixed": dict(ops_dtype=jnp.bfloat16, sensitive_ops_dtype=jnp.float32),
+}
 
-def _make_transformer(tokens):
+
+def _make_transformer(tokens, precision_mode="float32"):
     """Create a Transformer and common inputs for benchmarking."""
     config = TransformerConfig(
         latent_dim=128,
@@ -51,6 +57,7 @@ def _make_transformer(tokens):
         n_heads=4,
         n_ff=2,
         label_dim=32,
+        **PRECISION_MODES[precision_mode],
     )
     rngs = nnx.Rngs(0)
     transformer = Transformer(config=config, tokens=tokens, rngs=rngs)
@@ -66,9 +73,10 @@ class TestTransformerBenchmark:
     @pytest.mark.slow
     @pytest.mark.benchmark(group="forward")
     @pytest.mark.parametrize("seq_len", SEQ_LENS)
-    def test_forward_benchmark(self, benchmark, seq_len: int) -> None:
+    @pytest.mark.parametrize("precision_mode", PRECISION_MODES.keys())
+    def test_forward_benchmark(self, benchmark, seq_len: int, precision_mode: str) -> None:
         tokens = create_benchmark_tokens(BATCH_SIZE, seq_len)
-        transformer, time_input = _make_transformer(tokens)
+        transformer, time_input = _make_transformer(tokens, precision_mode)
 
         @nnx.jit
         def forward_fn(model, tokens, t):
@@ -87,9 +95,10 @@ class TestTransformerBenchmark:
     @pytest.mark.slow
     @pytest.mark.benchmark(group="backward")
     @pytest.mark.parametrize("seq_len", SEQ_LENS)
-    def test_backward_benchmark(self, benchmark, seq_len: int) -> None:
+    @pytest.mark.parametrize("precision_mode", PRECISION_MODES.keys())
+    def test_backward_benchmark(self, benchmark, seq_len: int, precision_mode: str) -> None:
         tokens = create_benchmark_tokens(BATCH_SIZE, seq_len)
-        transformer, time_input = _make_transformer(tokens)
+        transformer, time_input = _make_transformer(tokens, precision_mode)
 
         def loss_fn(model):
             output = model(tokens=tokens, time=time_input, deterministic=True)
@@ -108,17 +117,20 @@ class TestTransformerBenchmark:
 
         benchmark.pedantic(run, warmup_rounds=N_WARMUP, rounds=10, iterations=1)
 
-    # ── Memory (hand-rolled) ───────────────────────────────────
+    # ── Memory (peak usage via device.memory_stats) ────────────
+    #
+    # Reports peak_bytes_in_use after warmup+run for each config.
+    # Since peak is monotonic within a process, compare across
+    # precision modes at the same seq_len by running them in
+    # separate pytest-xdist workers or sequential invocations.
 
     @pytest.mark.slow
     @pytest.mark.parametrize("seq_len", SEQ_LENS)
-    def test_forward_peak_memory(self, seq_len: int) -> None:
+    @pytest.mark.parametrize("precision_mode", PRECISION_MODES.keys())
+    def test_forward_peak_memory(self, seq_len: int, precision_mode: str) -> None:
         device = jax.local_devices()[0]
-        if not hasattr(device, "memory_stats"):
-            pytest.skip("Device does not support memory_stats")
-
         tokens = create_benchmark_tokens(BATCH_SIZE, seq_len)
-        transformer, time_input = _make_transformer(tokens)
+        transformer, time_input = _make_transformer(tokens, precision_mode)
 
         @nnx.jit
         def forward_fn(model, tokens, t):
@@ -128,23 +140,20 @@ class TestTransformerBenchmark:
         for _ in range(N_WARMUP):
             forward_fn(transformer, tokens, time_input).block_until_ready()
 
-        _ = device.memory_stats()  # reset baseline
-        forward_fn(transformer, tokens, time_input).block_until_ready()
-
         stats = device.memory_stats()
-        if stats and "peak_bytes_in_use" in stats:
-            peak_mb = stats["peak_bytes_in_use"] / (1024 * 1024)
-            print(f"\nForward peak memory (seq_len={seq_len}): {peak_mb:.2f} MB")
+        if stats is None:
+            pytest.skip("memory_stats() unavailable (platform allocator?)")
+
+        peak_mb = stats["peak_bytes_in_use"] / (1024 * 1024)
+        print(f"\nForward peak memory (seq_len={seq_len}, {precision_mode}): {peak_mb:.2f} MB")
 
     @pytest.mark.slow
     @pytest.mark.parametrize("seq_len", SEQ_LENS)
-    def test_backward_peak_memory(self, seq_len: int) -> None:
+    @pytest.mark.parametrize("precision_mode", PRECISION_MODES.keys())
+    def test_backward_peak_memory(self, seq_len: int, precision_mode: str) -> None:
         device = jax.local_devices()[0]
-        if not hasattr(device, "memory_stats"):
-            pytest.skip("Device does not support memory_stats")
-
         tokens = create_benchmark_tokens(BATCH_SIZE, seq_len)
-        transformer, time_input = _make_transformer(tokens)
+        transformer, time_input = _make_transformer(tokens, precision_mode)
 
         def loss_fn(model):
             output = model(tokens=tokens, time=time_input, deterministic=True)
@@ -157,11 +166,9 @@ class TestTransformerBenchmark:
             loss, _ = grad_fn(transformer)
             loss.block_until_ready()
 
-        _ = device.memory_stats()  # reset baseline
-        loss, _ = grad_fn(transformer)
-        loss.block_until_ready()
-
         stats = device.memory_stats()
-        if stats and "peak_bytes_in_use" in stats:
-            peak_mb = stats["peak_bytes_in_use"] / (1024 * 1024)
-            print(f"\nBackward peak memory (seq_len={seq_len}): {peak_mb:.2f} MB")
+        if stats is None:
+            pytest.skip("memory_stats() unavailable (platform allocator?)")
+
+        peak_mb = stats["peak_bytes_in_use"] / (1024 * 1024)
+        print(f"\nBackward peak memory (seq_len={seq_len}, {precision_mode}): {peak_mb:.2f} MB")

--- a/test/test_nn/test_transformer/test_dtypes.py
+++ b/test/test_nn/test_transformer/test_dtypes.py
@@ -1,0 +1,81 @@
+"""Tests for mixed precision dtype propagation."""
+
+import pytest
+import jax.numpy as jnp
+from flax import nnx
+
+from tfmpe.preprocessing import Tokens, Labeller
+from tfmpe.nn.transformer import Transformer
+from tfmpe.nn.transformer.config import TransformerConfig
+
+PRECISION_MODES = {
+    "float32": dict(ops_dtype=jnp.float32, sensitive_ops_dtype=jnp.float32),
+    "bfloat16": dict(ops_dtype=jnp.bfloat16, sensitive_ops_dtype=jnp.bfloat16),
+    "mixed": dict(ops_dtype=jnp.bfloat16, sensitive_ops_dtype=jnp.float32),
+}
+
+
+def _make_transformer(tokens, precision_mode="float32"):
+    config = TransformerConfig(
+        latent_dim=64,
+        n_encoder=2,
+        n_heads=4,
+        n_ff=2,
+        label_dim=16,
+        **PRECISION_MODES[precision_mode],
+    )
+    rngs = nnx.Rngs(0)
+    return Transformer(config=config, tokens=tokens, rngs=rngs)
+
+
+class TestOutputDtype:
+    """Verify the output dtype of the transformer for each precision mode."""
+
+    @pytest.mark.parametrize("precision_mode,expected_dtype", [
+        ("float32", jnp.float32),
+        ("bfloat16", jnp.bfloat16),
+        ("mixed", jnp.bfloat16),
+    ])
+    def test_forward_output_dtype(
+        self, simple_tokens, precision_mode, expected_dtype
+    ):
+        transformer = _make_transformer(simple_tokens, precision_mode)
+        time = jnp.array(0.5)
+        output = transformer(tokens=simple_tokens, time=time)
+        assert output.dtype == expected_dtype
+
+    @pytest.mark.parametrize("precision_mode,expected_dtype", [
+        ("float32", jnp.float32),
+        ("bfloat16", jnp.bfloat16),
+        ("mixed", jnp.bfloat16),
+    ])
+    def test_encode_output_dtype(
+        self, simple_tokens, precision_mode, expected_dtype
+    ):
+        transformer = _make_transformer(simple_tokens, precision_mode)
+        time = jnp.array(0.5)
+        encoded = transformer.encode(tokens=simple_tokens, time=time)
+        assert encoded.dtype == expected_dtype
+
+
+class TestEmbeddingDtype:
+    """Verify embedding layer output dtype matches ops_dtype."""
+
+    @pytest.mark.parametrize("precision_mode", PRECISION_MODES.keys())
+    def test_embedding_output_dtype(self, simple_tokens, precision_mode):
+        transformer = _make_transformer(simple_tokens, precision_mode)
+        expected = PRECISION_MODES[precision_mode]["ops_dtype"]
+        time = jnp.array(0.5)
+        embedded = transformer.embedding(simple_tokens, time)
+        assert embedded.dtype == expected
+
+
+class TestOutputShapePreserved:
+    """Verify output shapes are unchanged across precision modes."""
+
+    @pytest.mark.parametrize("precision_mode", PRECISION_MODES.keys())
+    def test_output_shape(self, simple_tokens, precision_mode):
+        transformer = _make_transformer(simple_tokens, precision_mode)
+        time = jnp.array(0.5)
+        output = transformer(tokens=simple_tokens, time=time)
+        assert output.shape == (1, 3, 1)

--- a/test/test_nn/test_transformer/test_embedding.py
+++ b/test/test_nn/test_transformer/test_embedding.py
@@ -3,7 +3,6 @@
 import pytest
 import jax
 import jax.numpy as jnp
-from jax import random
 from flax import nnx
 
 from tfmpe.nn.transformer.embedding import (

--- a/test/test_nn/test_transformer/test_embedding.py
+++ b/test/test_nn/test_transformer/test_embedding.py
@@ -1,0 +1,268 @@
+"""Tests for transformer embedding components."""
+
+import pytest
+import jax
+import jax.numpy as jnp
+from jax import random
+from flax import nnx
+
+from tfmpe.nn.transformer.embedding import (
+    GaussianFourierEmbedding,
+    Embedding,
+)
+from tfmpe.preprocessing.tokens import Tokens
+from tfmpe.preprocessing.utils import Labeller
+
+
+class TestGaussianFourierEmbedding:
+    """Tests for GaussianFourierEmbedding layer."""
+
+    @pytest.mark.parametrize("in_dim,out_dim", [
+        (1, 2),
+        (1, 64),
+        (2, 4),
+        (3, 64),
+        (10, 128),
+    ])
+    def test_output_shape(self, in_dim: int, out_dim: int) -> None:
+        """Test that output shape matches expected dimensions.
+
+        Parameters
+        ----------
+        in_dim : int
+            Input feature dimension
+        out_dim : int
+            Output feature dimension
+        """
+        rngs = nnx.Rngs(0)
+        embedding = GaussianFourierEmbedding(in_dim, out_dim, rngs)
+
+        # Test with simple 1D input
+        inputs = jnp.ones((in_dim,))
+        output = embedding(inputs)
+        assert output.shape == (out_dim,), (
+            f"Expected shape {(out_dim,)}, got {output.shape}"
+        )
+
+    @pytest.mark.parametrize("batch_size", [1, 4, 32])
+    def test_batch_shape(self, batch_size: int) -> None:
+        """Test output shape with batch dimension.
+
+        Parameters
+        ----------
+        batch_size : int
+            Number of samples in batch
+        """
+        in_dim, out_dim = 3, 64
+        rngs = nnx.Rngs(0)
+        embedding = GaussianFourierEmbedding(in_dim, out_dim, rngs)
+
+        inputs = jnp.ones((batch_size, in_dim))
+        output = embedding(inputs)
+        assert output.shape == (batch_size, out_dim), (
+            f"Expected shape {(batch_size, out_dim)}, "
+            f"got {output.shape}"
+        )
+
+    @pytest.mark.parametrize(
+        "sample_dims,n_tokens,in_dim,out_dim",
+        [
+            ((2, 3), 10, 2, 64),
+            ((4,), 20, 3, 128),
+            ((2, 3, 4), 5, 1, 32),
+        ]
+    )
+    def test_multidimensional_batch(
+        self,
+        sample_dims: tuple,
+        n_tokens: int,
+        in_dim: int,
+        out_dim: int,
+    ) -> None:
+        """Test output shape with multiple sample dimensions.
+
+        Parameters
+        ----------
+        sample_dims : tuple
+            Sample dimensions before tokens
+        n_tokens : int
+            Number of tokens
+        in_dim : int
+            Input feature dimension
+        out_dim : int
+            Output feature dimension
+        """
+        rngs = nnx.Rngs(0)
+        embedding = GaussianFourierEmbedding(in_dim, out_dim, rngs)
+
+        shape = sample_dims + (n_tokens, in_dim)
+        inputs = jnp.ones(shape)
+        output = embedding(inputs)
+
+        expected_shape = sample_dims + (n_tokens, out_dim)
+        assert output.shape == expected_shape, (
+            f"Expected shape {expected_shape}, got {output.shape}"
+        )
+
+
+class TestEmbedding:
+    """Tests for Embedding layer."""
+
+    @pytest.fixture
+    def tokens_without_functional_inputs(self) -> Tokens:
+        """Create tokens without functional inputs."""
+        batch_size, n_tokens, value_dim = 4, 10, 2
+
+        return Tokens.from_pytree(
+            {'dummy': jnp.ones((batch_size, n_tokens, value_dim))},
+            condition=[],
+            labeller=Labeller(label_map={'dummy': 0}),
+        )
+
+    @pytest.fixture
+    def tokens_with_functional_inputs(self) -> Tokens:
+        """Create tokens with functional inputs."""
+        batch_size, n_tokens, value_dim = 4, 10, 2
+        functional_inputs_dim = 2
+
+        return Tokens.from_pytree(
+            {'dummy': jnp.ones((batch_size, n_tokens, value_dim))},
+            condition=[],
+            labeller=Labeller(label_map={'dummy': 0}),
+            functional_inputs={
+                'dummy':jnp.ones(
+                    (batch_size, n_tokens, functional_inputs_dim)
+                )
+            }
+        )
+
+    def test_output_shape_without_functional_inputs(
+        self,
+        tokens_without_functional_inputs: Tokens,
+    ) -> None:
+        """Test output shape without functional inputs.
+
+        Parameters
+        ----------
+        tokens_without_functional_inputs : Tokens
+            Tokens fixture without functional inputs
+        """
+        rngs = nnx.Rngs(0)
+        latent_dim = 128
+        value_dim = 2
+        n_labels = 5
+        label_dim = 32
+        pos_dim=2
+
+        embedding = Embedding(
+            value_dim=value_dim,
+            n_labels=n_labels,
+            label_dim=label_dim,
+            pos_dim=pos_dim,
+            latent_dim=latent_dim,
+            rngs=rngs
+        )
+
+        batch_size, n_tokens = 4, 10
+        time = jnp.array(0.5)
+        output = embedding(
+            tokens_without_functional_inputs,
+            time
+        )
+
+        expected_shape = (batch_size, n_tokens, latent_dim)
+        assert output.shape == expected_shape, (
+            f"Expected shape {expected_shape}, got {output.shape}"
+        )
+
+    def test_output_shape_with_functional_inputs(
+        self,
+        tokens_with_functional_inputs: Tokens,
+    ) -> None:
+        """Test output shape with functional inputs.
+
+        Parameters
+        ----------
+        tokens_with_functional_inputs : Tokens
+            Tokens fixture with functional inputs
+        """
+        rngs = nnx.Rngs(0)
+        latent_dim = 128
+        value_dim = 2
+        n_labels = 5
+        label_dim = 32
+        pos_dim = 2
+        functional_inputs_dim = 2
+
+        embedding = Embedding(
+            value_dim=value_dim,
+            n_labels=n_labels,
+            label_dim=label_dim,
+            latent_dim=latent_dim,
+            pos_dim=pos_dim,
+            rngs=rngs,
+            f_in_in_dim=functional_inputs_dim,
+            f_in_out_dim=functional_inputs_dim,
+        )
+
+        batch_size, n_tokens = 4, 10
+        time = jnp.array(0.5)
+        output = embedding(tokens_with_functional_inputs, time)
+
+        expected_shape = (batch_size, n_tokens, latent_dim)
+        assert output.shape == expected_shape, (
+            f"Expected shape {expected_shape}, got {output.shape}"
+        )
+
+    @pytest.mark.parametrize("sample_shape", [(2,), (2, 3), (4,)])
+    def test_sample_dimensions(
+        self,
+        tokens_without_functional_inputs: Tokens,
+        sample_shape: tuple,
+    ) -> None:
+        """Test with sample dimensions.
+
+        Parameters
+        ----------
+        tokens_without_functional_inputs : Tokens
+            Base tokens fixture
+        sample_shape : tuple
+            Sample dimensions
+        """
+        rngs = nnx.Rngs(0)
+        latent_dim = 128
+        value_dim = 2
+        n_labels = 5
+        label_dim = 32
+        pos_dim = 2
+
+        embedding = Embedding(
+            value_dim=value_dim,
+            n_labels=n_labels,
+            label_dim=label_dim,
+            pos_dim=pos_dim,
+            latent_dim=latent_dim,
+            rngs=rngs,
+        )
+
+        # Broadcast tokens to desired sample shape
+        def broadcast_to_shape(x: jnp.ndarray) -> jnp.ndarray:
+            """Broadcast array to sample shape."""
+            # Slice first element and broadcast to sample shape
+            first = x[0]
+            target_shape = sample_shape + first.shape
+            return jnp.broadcast_to(first, target_shape)
+
+        tokens = jax.tree.map(
+            broadcast_to_shape,
+            tokens_without_functional_inputs,
+        )
+
+        n_tokens = tokens_without_functional_inputs.data.shape[1]
+        time = jnp.array(0.)
+        output = embedding(tokens, time)
+
+        expected_shape = sample_shape + (n_tokens, latent_dim)
+        assert output.shape == expected_shape, (
+            f"Expected shape {expected_shape}, got {output.shape}"
+        )

--- a/test/test_nn/test_transformer/test_embedding.py
+++ b/test/test_nn/test_transformer/test_embedding.py
@@ -168,7 +168,6 @@ class TestEmbedding:
             tokens_without_functional_inputs,
             time
         )
-
         expected_shape = (batch_size, n_tokens, latent_dim)
         assert output.shape == expected_shape, (
             f"Expected shape {expected_shape}, got {output.shape}"

--- a/test/test_nn/test_transformer/test_embedding.py
+++ b/test/test_nn/test_transformer/test_embedding.py
@@ -159,6 +159,8 @@ class TestEmbedding:
             label_dim=label_dim,
             pos_dim=pos_dim,
             latent_dim=latent_dim,
+            max_positions=128,
+            max_groups=128,
             rngs=rngs
         )
 
@@ -199,6 +201,8 @@ class TestEmbedding:
             latent_dim=latent_dim,
             pos_dim=pos_dim,
             rngs=rngs,
+            max_positions=128,
+            max_groups=128,
             f_in_in_dim=functional_inputs_dim,
             f_in_out_dim=functional_inputs_dim,
         )
@@ -240,6 +244,8 @@ class TestEmbedding:
             label_dim=label_dim,
             pos_dim=pos_dim,
             latent_dim=latent_dim,
+            max_positions=128,
+            max_groups=128,
             rngs=rngs,
         )
 

--- a/test/test_nn/test_transformer/test_encoder.py
+++ b/test/test_nn/test_transformer/test_encoder.py
@@ -1,0 +1,127 @@
+"""Tests for transformer encoder components (MLP)."""
+
+import pytest
+import jax.numpy as jnp
+from flax import nnx
+
+from tfmpe.nn.transformer.config import TransformerConfig
+from tfmpe.nn.transformer.encoder import MLP
+
+
+class TestMLP:
+    """Tests for MLP feedforward network."""
+
+    @pytest.mark.parametrize("n_ff", [1, 2, 4, 8])
+    def test_output_shape_preservation(self, n_ff: int) -> None:
+        """Test that MLP preserves input shape.
+
+        Parameters
+        ----------
+        n_ff : int
+            Number of feedforward layers
+        """
+        rngs = nnx.Rngs(0)
+        config = TransformerConfig(
+            latent_dim=128,
+            n_encoder=4,
+            n_heads=8,
+            n_ff=n_ff,
+            label_dim=32,
+            index_out_dim=64,
+            dropout=0.1,
+        )
+
+        mlp = MLP(config=config, rngs=rngs)
+
+        batch_size, n_tokens = 4, 10
+        inputs = jnp.ones((batch_size, n_tokens, config.latent_dim))
+        output = mlp(inputs)
+
+        expected_shape = (batch_size, n_tokens, config.latent_dim)
+        assert output.shape == expected_shape, (
+            f"Expected shape {expected_shape}, got {output.shape}"
+        )
+
+    @pytest.mark.parametrize("batch_size", [1, 4, 16])
+    def test_different_batch_sizes(self, batch_size: int) -> None:
+        """Test MLP with different batch sizes.
+
+        Parameters
+        ----------
+        batch_size : int
+            Number of samples in batch
+        """
+        rngs = nnx.Rngs(0)
+        config = TransformerConfig(
+            latent_dim=64,
+            n_encoder=2,
+            n_heads=4,
+            n_ff=2,
+            label_dim=16,
+            index_out_dim=32,
+            dropout=0.1,
+        )
+
+        mlp = MLP(config=config, rngs=rngs)
+
+        n_tokens = 20
+        inputs = jnp.ones((batch_size, n_tokens, config.latent_dim))
+        output = mlp(inputs)
+
+        expected_shape = (batch_size, n_tokens, config.latent_dim)
+        assert output.shape == expected_shape, (
+            f"Expected shape {expected_shape}, got {output.shape}"
+        )
+
+    def test_train_eval_dropout_difference(self) -> None:
+        """Test that dropout behaves differently in train vs eval mode."""
+        rngs = nnx.Rngs(0)
+        config = TransformerConfig(
+            latent_dim=128,
+            n_encoder=4,
+            n_heads=8,
+            n_ff=2,
+            label_dim=32,
+            index_out_dim=64,
+            dropout=0.5,
+        )
+
+        mlp = MLP(config=config, rngs=rngs)
+
+        batch_size, n_tokens = 4, 10
+        inputs = jnp.ones((batch_size, n_tokens, config.latent_dim))
+
+        # Set to eval mode
+        mlp.eval()
+        eval_output = mlp(inputs)
+
+        # In eval mode, output should be deterministic
+        eval_output_2 = mlp(inputs)
+        assert jnp.allclose(eval_output, eval_output_2), (
+            "Eval mode should produce deterministic outputs"
+        )
+
+    def test_with_multidimensional_batch(self) -> None:
+        """Test MLP with multiple sample dimensions."""
+        rngs = nnx.Rngs(0)
+        config = TransformerConfig(
+            latent_dim=64,
+            n_encoder=2,
+            n_heads=4,
+            n_ff=2,
+            label_dim=16,
+            index_out_dim=32,
+            dropout=0.1,
+        )
+
+        mlp = MLP(config=config, rngs=rngs)
+
+        # Shape: (samples, batch, n_tokens, latent_dim)
+        inputs = jnp.ones((2, 3, 10, config.latent_dim))
+        output = mlp(inputs)
+
+        expected_shape = (2, 3, 10, config.latent_dim)
+        assert output.shape == expected_shape, (
+            f"Expected shape {expected_shape}, got {output.shape}"
+        )
+

--- a/test/test_nn/test_transformer/test_transformer.py
+++ b/test/test_nn/test_transformer/test_transformer.py
@@ -1,0 +1,253 @@
+"""Tests for Transformer model end-to-end functionality."""
+
+import pytest
+import jax.numpy as jnp
+from flax import nnx
+
+from tfmpe.preprocessing import Tokens, Labeller
+from tfmpe.nn.transformer import Transformer
+from tfmpe.nn.transformer.config import TransformerConfig
+
+class TestTransformerInit:
+    """Tests for Transformer initialization."""
+
+    def test_init_deduces_params_from_tokens(
+        self,
+        simple_tokens: Tokens,
+    ) -> None:
+        """Test that Transformer.__init__ deduces all params from
+        Tokens."""
+        config = TransformerConfig(
+            latent_dim=128,
+            n_encoder=2,
+            n_heads=8,
+            n_ff=2,
+            label_dim=32,
+            index_out_dim=64,
+            dropout=0.1,
+        )
+
+        rngs = nnx.Rngs(0)
+
+        # Initialize transformer - deduce value_dim, n_labels,
+        # functional_inputs_dim from tokens
+        transformer = Transformer(
+            config=config,
+            tokens=simple_tokens,
+            rngs=rngs,
+        )
+
+        assert transformer is not None
+
+    def test_init_accepts_config_dataclass(
+        self,
+        simple_tokens: Tokens,
+    ) -> None:
+        """Test that Transformer.__init__ accepts config dataclass."""
+        config = TransformerConfig(
+            latent_dim=128,
+            n_encoder=2,
+            n_heads=8,
+            n_ff=2,
+            label_dim=32,
+            index_out_dim=64,
+            dropout=0.1,
+        )
+
+        rngs = nnx.Rngs(0)
+
+        # Should accept config as primary parameter
+        transformer = Transformer(
+            config=config,
+            tokens=simple_tokens,
+            rngs=rngs,
+        )
+
+        assert transformer is not None
+
+
+class TestTransformerForwardPass:
+    """Tests for Transformer forward pass."""
+
+    def test_forward_pass_output_shape(
+        self,
+        simple_tokens: Tokens,
+    ) -> None:
+        """Test forward pass output shape matches input param
+        shape."""
+        config = TransformerConfig(
+            latent_dim=64,
+            n_encoder=2,
+            n_heads=4,
+            n_ff=2,
+            label_dim=16,
+            index_out_dim=32,
+            dropout=0.1,
+        )
+
+        rngs = nnx.Rngs(0)
+
+        transformer = Transformer(
+            config=config,
+            tokens=simple_tokens,
+            rngs=rngs,
+        )
+
+        # Time is a scalar for now
+        time = jnp.array(0.5)
+
+        # Forward pass using __call__
+        output = transformer(
+            tokens=simple_tokens,
+            time=time,
+        )
+
+        expected_shape = (1, 3, 1)
+        assert output.shape == expected_shape, (
+            f"Expected shape {expected_shape}, got {output.shape}"
+        )
+
+    @pytest.mark.parametrize(
+        "n_param_tokens,latent_dim",
+        [
+            (2, 64),
+            (5, 128),
+        ],
+    )
+    def test_forward_pass_various_sizes(
+        self,
+        n_param_tokens: int,
+        latent_dim: int,
+    ) -> None:
+        """Test forward pass with various token and latent
+        dimensions."""
+        # Create labeller for this test
+        labeller = Labeller(label_map={'context': 0, 'param': 1})
+
+        # Create context and param tokens
+        data = {
+            'context': jnp.ones((1, 2, 1)),
+            'param': jnp.ones((1, n_param_tokens, 1))
+        }
+
+        tokens = Tokens.from_pytree(
+            data,
+            labeller=labeller,
+            condition=['context'],
+            sample_ndims=1,
+        )
+
+        config = TransformerConfig(
+            latent_dim=latent_dim,
+            n_encoder=2,
+            n_heads=min(4, latent_dim // 16),
+            n_ff=2,
+            label_dim=16,
+            index_out_dim=32,
+            dropout=0.1,
+        )
+
+        rngs = nnx.Rngs(0)
+        transformer = Transformer(
+            config,
+            tokens=tokens,
+            rngs=rngs,
+        )
+
+        time = jnp.array(0.5)
+        output = transformer(
+            tokens=tokens,
+            time=time,
+        )
+
+        # Expected shape: param is (n_param_tokens, 1)
+        expected_shape = (1, n_param_tokens, 1)
+        assert output.shape == expected_shape
+
+
+class TestTransformerEncode:
+    """Tests for Transformer.encode method."""
+
+    def test_encode_method_output_shape(
+        self,
+        simple_tokens: Tokens,
+    ) -> None:
+        """Test encode method returns correct shape."""
+        config = TransformerConfig(
+            latent_dim=64,
+            n_encoder=2,
+            n_heads=4,
+            n_ff=2,
+            label_dim=16,
+            index_out_dim=32,
+            dropout=0.1,
+        )
+
+        rngs = nnx.Rngs(0)
+
+        transformer = Transformer(
+            config=config,
+            tokens=simple_tokens,
+            rngs=rngs,
+        )
+
+        time = jnp.array(0.5)
+
+        # Encode context tokens
+        encoded = transformer.encode(
+            tokens=simple_tokens,
+            time=time,
+        )
+
+        # Expected shape: (3 tokens total for mu + obs, latent_dim)
+        expected_shape = (1, 3, config.latent_dim)
+        assert encoded.shape == expected_shape
+
+class TestTransformerSampleDimensions:
+    """Tests for Transformer with multiple sample dimensions."""
+
+    def test_sample_same_sample_dimensions(self) -> None:
+        """Test __call__ with same sample dimensions for both
+        tokens."""
+        # Create labeller for this test
+        labeller = Labeller(label_map={'context': 0, 'param': 1})
+
+        # Create context and param tokens
+        tokens = Tokens.from_pytree(
+            {
+                'param': jnp.ones((2, 4, 5, 1)),
+                'context': jnp.ones((2, 4, 3, 1))
+            },
+            condition=['context'],
+            labeller=labeller,
+            sample_ndims=2,
+            batch_ndims={'context': 1},
+        )
+
+        config = TransformerConfig(
+            latent_dim=64,
+            n_encoder=2,
+            n_heads=4,
+            n_ff=2,
+            label_dim=16,
+            index_out_dim=32,
+            dropout=0.1,
+        )
+
+        rngs = nnx.Rngs(0)
+        transformer = Transformer(
+            config=config,
+            tokens=tokens,
+            rngs=rngs,
+        )
+
+        time = jnp.ones((2, 4))
+
+        output = transformer(
+            tokens=tokens,
+            time=time,
+        )
+
+        # Expected shape: param is (2, 4, 5, 1)
+        expected_shape = (2, 4, 5, 1)
+        assert output.shape == expected_shape

--- a/test/test_preprocessing/conftest.py
+++ b/test/test_preprocessing/conftest.py
@@ -3,7 +3,6 @@
 import jax.numpy as jnp
 import pytest
 
-
 @pytest.fixture
 def simple_pytree():
     """Simple pytree with 3 keys, no sample dimensions.

--- a/test/test_preprocessing/test_tokens_basic.py
+++ b/test/test_preprocessing/test_tokens_basic.py
@@ -12,7 +12,8 @@ def test_from_pytree_data_shape(simple_pytree):
         simple_pytree,
         condition=['obs'],
         sample_ndims=0,
-        batch_ndims={'mu': 1, 'theta': 1, 'obs': 1}
+        batch_ndims={'mu': 1, 'theta': 1, 'obs': 1},
+        pad_to_even=False,
     )
 
     # Total tokens: 1 (mu) + 3 (theta) + 3 (obs) = 7
@@ -26,7 +27,8 @@ def test_from_pytree_labels_shape(simple_pytree):
         simple_pytree,
         condition=['obs'],
         sample_ndims=0,
-        batch_ndims={'mu': 1, 'theta': 1, 'obs': 1}
+        batch_ndims={'mu': 1, 'theta': 1, 'obs': 1},
+        pad_to_even=False,
     )
 
     # Labels should have shape (7,) for 7 total tokens
@@ -59,7 +61,8 @@ def test_from_pytree_labels_with_sample_dims():
         pytree,
         condition=[],
         sample_ndims=1,
-        batch_ndims={'a': 1, 'b': 1}
+        batch_ndims={'a': 1, 'b': 1},
+        pad_to_even=False,
     )
 
     # Labels should have shape (2, 3) for 2 samples, 3 total tokens
@@ -83,6 +86,7 @@ def test_decode_round_trip(simple_pytree):
         condition=['obs'],
         sample_ndims=0,
         batch_ndims={'mu': 1, 'theta': 1, 'obs': 1},
+        pad_to_even=False,
     )
 
     reconstructed = decoder(tokens)
@@ -143,7 +147,8 @@ def test_from_pytree_with_functional_inputs(simple_pytree):
         condition=['obs'],
         functional_inputs=functional_inputs,
         sample_ndims=0,
-        batch_ndims={'mu': 1, 'theta': 1, 'obs': 1}
+        batch_ndims={'mu': 1, 'theta': 1, 'obs': 1},
+        pad_to_even=False,
     )
 
     # Check functional_inputs is not None
@@ -170,10 +175,130 @@ def test_from_pytree_functional_inputs_with_sample_dims():
         condition=[],
         functional_inputs=functional_inputs,
         sample_ndims=1,
-        batch_ndims={'a': 1, 'b': 1}
+        batch_ndims={'a': 1, 'b': 1},
+        pad_to_even=False,
     )
 
     # Check functional_inputs shape: (2, 3, 1)
     assert tokens.functional_inputs is not None
     assert tokens.functional_inputs.shape == (2, 3, 1)
     assert tokens.functional_inputs.shape == tokens.data.shape
+
+
+# --- pad_to_even=True tests ---
+
+def test_pad_to_even_data_shape(simple_pytree):
+    """Test that odd token count gets padded to even."""
+    tokens = Tokens.from_pytree(
+        simple_pytree,
+        condition=['obs'],
+        sample_ndims=0,
+        batch_ndims={'mu': 1, 'theta': 1, 'obs': 1},
+        pad_to_even=True,
+    )
+
+    # 7 tokens padded to 8
+    assert tokens.data.shape == (8, 1)
+
+
+def test_pad_to_even_padding_mask(simple_pytree):
+    """Test that padding mask marks real vs padded tokens."""
+    tokens = Tokens.from_pytree(
+        simple_pytree,
+        condition=['obs'],
+        sample_ndims=0,
+        batch_ndims={'mu': 1, 'theta': 1, 'obs': 1},
+        pad_to_even=True,
+    )
+
+    assert tokens.padding_mask is not None
+    assert tokens.padding_mask.shape == (8,)
+    # First 7 are real, last 1 is padding
+    assert jnp.all(tokens.padding_mask[:7] == 1.0)
+    assert tokens.padding_mask[7] == 0.0
+
+
+def test_pad_to_even_no_pad_when_even():
+    """Test that even token count is not padded."""
+    pytree = {
+        'a': jnp.array([[[1.0], [2.0]], [[3.0], [4.0]]]),  # (2, 2, 1)
+        'b': jnp.array([[[5.0], [6.0]], [[7.0], [8.0]]])    # (2, 2, 1)
+    }
+
+    tokens = Tokens.from_pytree(
+        pytree,
+        condition=[],
+        sample_ndims=1,
+        batch_ndims={'a': 1, 'b': 1},
+        pad_to_even=True,
+    )
+
+    # 4 tokens already even, no padding
+    assert tokens.data.shape == (2, 4, 1)
+    assert tokens.padding_mask is None
+
+
+def test_pad_to_even_labels_with_sample_dims():
+    """Test padded labels with sample dimensions."""
+    pytree = {
+        'a': jnp.array([[[1.0], [2.0]], [[3.0], [4.0]]]),  # (2, 2, 1)
+        'b': jnp.array([[[5.0]], [[6.0]]])  # (2, 1, 1)
+    }
+
+    tokens = Tokens.from_pytree(
+        pytree,
+        condition=[],
+        sample_ndims=1,
+        batch_ndims={'a': 1, 'b': 1},
+        pad_to_even=True,
+    )
+
+    # 3 tokens padded to 4
+    assert tokens.labels.shape == (2, 4)
+    assert tokens.padding_mask is not None
+    assert tokens.padding_mask.shape == (2, 4)
+    assert jnp.all(tokens.padding_mask[:, :3] == 1.0)
+    assert jnp.all(tokens.padding_mask[:, 3] == 0.0)
+
+
+def test_pad_to_even_decode_round_trip(simple_pytree):
+    """Test that decoder strips padding and recovers original PyTree."""
+    tokens, decoder = Tokens.from_pytree_with_decoder(
+        simple_pytree,
+        condition=['obs'],
+        sample_ndims=0,
+        batch_ndims={'mu': 1, 'theta': 1, 'obs': 1},
+        pad_to_even=True,
+    )
+
+    # Tokens are padded
+    assert tokens.data.shape == (8, 1)
+
+    # But decoder recovers original values
+    reconstructed = decoder(tokens)
+    assert set(reconstructed.keys()) == set(simple_pytree.keys())
+    for key in simple_pytree:
+        assert reconstructed[key].shape == simple_pytree[key].shape
+        assert jnp.allclose(reconstructed[key], simple_pytree[key])
+
+
+def test_pad_to_even_functional_inputs(simple_pytree):
+    """Test that functional inputs are also padded."""
+    functional_inputs = {
+        'mu': jnp.array([[0.0]]),
+        'theta': jnp.array([[1.0], [1.0], [1.0]]),
+        'obs': jnp.array([[2.0], [2.1], [2.2]])
+    }
+
+    tokens = Tokens.from_pytree(
+        simple_pytree,
+        condition=['obs'],
+        functional_inputs=functional_inputs,
+        sample_ndims=0,
+        batch_ndims={'mu': 1, 'theta': 1, 'obs': 1},
+        pad_to_even=True,
+    )
+
+    assert tokens.functional_inputs is not None
+    assert tokens.functional_inputs.shape == tokens.data.shape
+    assert tokens.data.shape == (8, 1)

--- a/tfmpe/estimators/__init__.py
+++ b/tfmpe/estimators/__init__.py
@@ -1,3 +1,5 @@
 """Parameter estimators."""
 
-__all__ = []
+from .tfmpe import TFMPE
+
+__all__ = ["TFMPE"]

--- a/tfmpe/estimators/ode.py
+++ b/tfmpe/estimators/ode.py
@@ -12,6 +12,18 @@ from jaxtyping import Array, Scalar
 from ..preprocessing.tokens import Tokens
 
 
+def _make_step_controller(solver, rtol, atol):
+    """Pick step controller based on solver capabilities.
+
+    Adaptive solvers (e.g. Dopri5, Heun) use PIDController.
+    Fixed-order solvers without error estimates (e.g. Euler)
+    use ConstantStepSize.
+    """
+    if isinstance(solver, diffrax.AbstractAdaptiveSolver):
+        return diffrax.PIDController(rtol=rtol, atol=atol), None
+    return diffrax.ConstantStepSize(), 0.01
+
+
 def solve_forward_ode(
     vf_fn: Callable[[Tokens, Scalar], Array],
     tokens: Tokens,
@@ -54,16 +66,15 @@ def solve_forward_ode(
 
     y0 = tokens.data[tokens.partition_idx:]
 
-    step_controller = diffrax.PIDController(
-        rtol=rtol,
-        atol=atol,
+    step_controller, dt0 = _make_step_controller(
+        solver, rtol, atol
     )
     solution = diffrax.diffeqsolve(
         diffrax.ODETerm(ode_func),
         solver,
         t0=0.0,
         t1=1.0,
-        dt0=None,
+        dt0=dt0,
         y0=y0,
         stepsize_controller=step_controller,
         saveat=diffrax.SaveAt(t1=True),
@@ -177,9 +188,8 @@ def solve_augmented_ode(
         jnp.array(0.0)
     )
 
-    step_controller = diffrax.PIDController(
-        rtol=rtol,
-        atol=atol,
+    step_controller, dt0 = _make_step_controller(
+        solver, rtol, atol
     )
     # Integrate from -1 to 0 (equivalent to t=1 to t=0)
     solution = diffrax.diffeqsolve(
@@ -187,7 +197,7 @@ def solve_augmented_ode(
         solver,
         t0=-1.0,
         t1=0.0,
-        dt0=None,
+        dt0=dt0,
         y0=aug_y0,
         stepsize_controller=step_controller,
         saveat=diffrax.SaveAt(t1=True),

--- a/tfmpe/estimators/ode.py
+++ b/tfmpe/estimators/ode.py
@@ -1,0 +1,206 @@
+"""ODE solving helpers for flow matching estimators."""
+
+from typing import Callable, Tuple
+import dataclasses
+
+import diffrax
+import jax
+import jax.numpy as jnp
+from jax import tree
+from jaxtyping import Array, Scalar
+
+from ..preprocessing.tokens import Tokens
+
+
+def solve_forward_ode(
+    vf_fn: Callable[[Tokens, Scalar], Array],
+    tokens: Tokens,
+    solver,
+    rtol: float = 1e-5,
+    atol: float = 1e-5,
+) -> Tokens:
+    """Solve forward ODE from t=0 to t=1 for sampling.
+
+    Parameters
+    ----------
+    vf_fn : Callable
+        Vector field function f(context, params, t) -> Array
+    tokens: Tokens
+        Singleton tokens for integration
+    solver : diffrax solver
+        Solver instance (e.g., Diffrax Dopri5)
+    rtol : float
+        Relative tolerance for ODE solver
+    atol : float
+        Absolute tolerance for ODE solver
+
+    Returns
+    -------
+    Tokens
+        Final target tokens at t=1
+    """
+    def ode_func(t, y_data: Array, args) -> Array:
+        data = tokens.data.at[tokens.partition_idx:].set(y_data)
+        tokens_t = dataclasses.replace(
+            tokens,
+            data=data
+        )
+        tokens_t = tree.map(
+            lambda leaf: leaf[None,...],
+            tokens_t
+        )
+        v = vf_fn(tokens_t, t)
+        return v[0]
+
+    y0 = tokens.data[tokens.partition_idx:]
+
+    step_controller = diffrax.PIDController(
+        rtol=rtol,
+        atol=atol,
+    )
+    solution = diffrax.diffeqsolve(
+        diffrax.ODETerm(ode_func),
+        solver,
+        t0=0.0,
+        t1=1.0,
+        dt0=None,
+        y0=y0,
+        stepsize_controller=step_controller,
+        saveat=diffrax.SaveAt(t1=True),
+    )
+
+    assert solution.ys is not None
+    output_tokens = dataclasses.replace(
+        tokens,
+        data=tokens.data.at[tokens.partition_idx:].set(solution.ys[0])
+    )
+    return output_tokens
+
+def solve_augmented_ode(
+    vf_fn: Callable[[Tokens, Scalar], Array],
+    tokens: Tokens,
+    solver,
+    rng: Array,
+    rtol: float = 1e-5,
+    atol: float = 1e-5,
+    n_epsilon: int = 1,
+) -> Tuple[Tokens, Scalar]:
+    """Solve augmented backward ODE for FFJORD log probability.
+
+    Augmented state: [params, log_det_jacobian]
+
+    Solves backward from t=1 to t=0 using FFJORD algorithm.
+    Uses stochastic trace estimation via VJP.
+
+    Parameters
+    ----------
+    vf_fn : Callable
+        Vector field function f(context, params, t) -> Array
+    context : Tokens
+        Context tokens (fixed during integration)
+    params : Tokens
+        Parameter tokens being evolved
+    solver : diffrax solver
+        Solver instance
+    rtol : float
+        Relative tolerance for ODE solver
+    atol : float
+        Absolute tolerance for ODE solver
+    rng : PRNGKeyArray, optional
+        PRNG key for sampling epsilon. If None, uses PRNGKey(0)
+    n_epsilon : int
+        Number of trace samples for Hutchinson estimator
+
+    Returns
+    -------
+    Tuple[Tokens, Scalar]
+        (final_params at t=0, final_log_det_jacobian)
+    """
+    # Pre-sample epsilon array for stochastic trace estimation
+    n_tokens = tokens.data.shape[0] - tokens.partition_idx
+    epsilon_array = jax.random.normal(
+        rng, (n_epsilon, n_tokens) + tokens.data.shape[1:]
+    )
+
+    # Backward integration: negate both time and vector field
+    vector_sign = -1.0
+
+    def augmented_ode_func(
+        t,
+        aug_state: Tuple[Array, Scalar],
+        args,
+    ) -> Tuple[Array, Scalar]:
+        y_data, _ = aug_state
+
+        # Map ODE time back to original time direction
+        # ODE integrates from t=1 to t=0 as t goes from -1 to 0
+        # So actual time is -t
+        actual_time = -t
+
+        # Compute vector field at actual time
+        def vf_wrapper(y_inner):
+            # Apply vector sign to both time and dynamics
+            inner_data = tokens.data.at[tokens.partition_idx:].set(y_inner)
+            inner_tokens = dataclasses.replace(
+                tokens,
+                data = inner_data
+            )
+            inner_tokens = tree.map(
+                lambda leaf: leaf[None, ...],
+                inner_tokens
+            )
+            return vector_sign * vf_fn(
+                inner_tokens, actual_time
+            )[0]
+
+        # Compute trace via stochastic VJP
+        # tr(∂f/∂x) ≈ mean_i[eps_i^T @ (∂f/∂x)^T @ eps_i]
+        _, vjp_fn = jax.vjp(vf_wrapper, y_data)
+
+        def compute_trace_single(eps):
+            g = vjp_fn(eps)[0]
+            return jnp.sum(g * eps)
+
+        # Average over all epsilon samples
+        trace_estimates = jax.vmap(
+            compute_trace_single, in_axes=0
+        )(epsilon_array)
+        trace_estimate = jnp.mean(trace_estimates)
+
+        # Return augmented dynamics
+        f_y = vf_wrapper(y_data)
+        return (f_y, -trace_estimate)
+
+    # Initial augmented state at t=1
+    aug_y0 = (
+        tokens.data[tokens.partition_idx:],
+        jnp.array(0.0)
+    )
+
+    step_controller = diffrax.PIDController(
+        rtol=rtol,
+        atol=atol,
+    )
+    # Integrate from -1 to 0 (equivalent to t=1 to t=0)
+    solution = diffrax.diffeqsolve(
+        diffrax.ODETerm(augmented_ode_func),
+        solver,
+        t0=-1.0,
+        t1=0.0,
+        dt0=None,
+        y0=aug_y0,
+        stepsize_controller=step_controller,
+        saveat=diffrax.SaveAt(t1=True),
+    )
+
+    # solution.ys is a tuple (y_trajectory, log_det_trajectory)
+    # With saveat=SaveAt(t1=True), each has 1 element along time
+    assert solution.ys is not None
+    final_y_data = solution.ys[0][0]
+    final_log_det = solution.ys[1][0]
+    final_data = tokens.data.at[tokens.partition_idx:].set(final_y_data)
+    final_tokens = dataclasses.replace(
+        tokens,
+        data = final_data
+    )
+    return final_tokens, final_log_det

--- a/tfmpe/estimators/proposals.py
+++ b/tfmpe/estimators/proposals.py
@@ -1,0 +1,331 @@
+from typing import Callable, Optional, Dict, Tuple
+from jaxtyping import Array, PyTree
+
+from jax import tree, numpy as jnp, random as jr
+
+from .tfmpe import TFMPE
+from ..preprocessing.utils import Labeller
+from ..preprocessing.tokens import Tokens
+
+def truncated_proposal_rejection(
+    key: Array,
+    model: TFMPE,
+    labeller: Labeller,
+    f_in: Dict[str, Array],
+    n_samples: int,
+    epsilon: float,
+    y_obs: Dict[str, Array],
+    prior_fn: Callable,
+    n: int,
+    prior_log_prob: Callable[[PyTree], float],
+    prob_transform: Optional[Callable[[PyTree, Array], float]] = None,
+    n_estimate: int =  10_000, #1_000_000,
+    n_batch: Optional[int] = None,
+    ) -> PyTree:
+    """Sample truncated proposal via sampling importance resampling"""
+    if n_batch is None:
+        n_batch = n_samples
+    estimate_key, key = jr.split(key)
+
+    print('estimating tau')
+
+    print('Sampling')
+    samples, log_prob = _batch_sample(
+        estimate_key,
+        model,
+        labeller,
+        prior_fn,
+        n,
+        y_obs,
+        f_in,
+        n_batch,
+        n_estimate,
+        prob_transform,
+    )
+
+    tau = jnp.quantile(log_prob, epsilon)
+    m = jnp.zeros((0,))
+    print(f"tau = {tau}")
+
+    while jnp.sum(m) < n_samples:
+        print(f'progress: {jnp.sum(m)} out of {n_samples}')
+        sample_key, key = jr.split(key)
+        new_samples, new_log_prob = _batch_sample_prior(
+            sample_key,
+            model,
+            labeller,
+            prior_fn,
+            n,
+            y_obs,
+            f_in,
+            n_batch,
+            n_batch,
+            prob_transform,
+        )
+        samples = tree.map(
+            lambda x, y: jnp.concatenate([x, y]),
+            samples,
+            new_samples
+        )
+        log_prob = jnp.concatenate([
+            log_prob,
+            new_log_prob
+        ])
+        m = jnp.concatenate([
+            m,
+            log_prob > tau
+        ])
+
+    samples = tree.map(
+        lambda leaf: jnp.compress(m, leaf, axis=0)[:n_samples],
+        samples
+    )
+    print(f"e.g.: {tree.map(lambda leaf: leaf[:2], samples)}")
+
+    return samples
+
+def truncated_proposal_sir(
+    key: Array,
+    model: TFMPE,
+    labeller: Labeller,
+    f_in: Dict[str, Array],
+    n_samples: int,
+    epsilon: float,
+    y_obs: Dict[str, Array],
+    prior_fn: Callable,
+    n: int,
+    prior_log_prob: Callable[[PyTree], float],
+    prob_transform: Optional[Callable[[PyTree, Array], float]] = None,
+    n_estimate: int =  10_000, #1_000_000,
+    n_batch: Optional[int] = None,
+    ) -> PyTree:
+    """Sample truncated proposal via sampling importance resampling"""
+    if n_batch is None:
+        n_batch = n_samples
+    estimate_key, resample_key = jr.split(key)
+
+    print('estimating tau')
+
+    print('Sampling')
+    samples, log_prob = _batch_sample(
+        estimate_key,
+        model,
+        labeller,
+        prior_fn,
+        n,
+        y_obs,
+        f_in,
+        n_batch,
+        n_estimate,
+        prob_transform,
+    )
+
+    tau = jnp.quantile(log_prob, epsilon)
+    m = log_prob > tau
+    print(f"tau = {tau}")
+    print(f"acceptance = {jnp.sum(m) / n_estimate}")
+    print(f"e.g.: {tree.map(lambda leaf: jnp.compress(m, leaf, axis=0)[:3], samples)}")
+
+    print('Importance')
+    w = prior_log_prob(samples) - log_prob
+    m = log_prob > tau
+    n_w = jnp.sum(m)
+    print(f"w_in_m = {jnp.extract(m, w)}")
+    print(f"n_w = {n_w}")
+
+    print('resampling')
+    indices = jr.categorical(
+        resample_key,
+        logits=jnp.extract(m, w),
+        shape=(n_samples,),
+        replace=True
+    )
+
+    samples = tree.map(
+        lambda leaf: jnp.compress(m, leaf, axis=0)[indices],
+        samples
+    )
+    print(f"e.g.: {tree.map(lambda leaf: leaf[:2], samples)}")
+
+    return samples
+
+def _batch_sample(
+    key: Array,
+    model: TFMPE,
+    labeller: Labeller,
+    prior_fn: Callable,
+    n: int,
+    y_obs: Dict[str, Array],
+    f_in: Dict[str, Array],
+    n_batch: int,
+    n_total: int,
+    prob_transform: Optional[Callable[[PyTree, Array], float]] = None,
+    ) -> Tuple[PyTree, Array]:
+    """Estimate threshold for High Probability Region of approximate posterior"""
+    samples, _ = prior_fn(
+        key,
+        n=n,
+        n_samples=1,
+    )
+
+    theta_template = tree.map(
+        lambda leaf: jnp.zeros(
+            (n_batch,) + leaf.shape[1:]
+        ),
+        samples
+    )
+    y_expanded = tree.map(
+        lambda leaf: jnp.broadcast_to(
+            leaf,
+            (n_batch,) + leaf.shape[1:]
+        ),
+        y_obs
+    )
+
+    tokens, decoder = Tokens.from_pytree_with_decoder(
+        {**y_expanded, **theta_template},
+        condition=list(y_expanded.keys()),
+        labeller=labeller,
+        sample_ndims=1,
+        functional_inputs=f_in,
+    )
+
+    n_sampled: int = 0
+    all_tokens = None
+    log_prob = jnp.array([])
+
+    while True:
+        print(f'progress: {n_sampled} of {n_total}')
+        print(f'sampling {n_batch}')
+
+        output_tokens = model.sample_posterior(tokens)
+        new_log_prob = model.log_prob_posterior_samples(output_tokens)
+
+        print(f'new_log_prob: {new_log_prob}')
+        print(f'new_log_prob shape: {new_log_prob.shape}')
+
+        if prob_transform is not None:
+            new_log_prob = prob_transform(decoder(output_tokens), new_log_prob)
+
+        print(f'new_log_prob (post transform): {new_log_prob}')
+
+        log_prob = jnp.concatenate([log_prob, new_log_prob])
+
+        if all_tokens is None:
+            all_tokens = output_tokens
+        else:
+            all_tokens = tree.map(
+                lambda x, y: jnp.concatenate([x, y]),
+                all_tokens,
+                output_tokens
+            )
+
+        n_sampled += n_batch
+
+        if n_sampled >= n_total:
+            break
+
+    values = decoder(all_tokens)
+    values = {
+        k: v
+        for k, v in values.items()
+        if k in theta_template.keys()
+    }
+
+    return values, log_prob
+
+def _batch_sample_prior(
+    key: Array,
+    model: TFMPE,
+    labeller: Labeller,
+    prior_fn: Callable,
+    n: int,
+    y_obs: Dict[str, Array],
+    f_in: Dict[str, Array],
+    n_batch: int,
+    n_total: int,
+    prob_transform: Optional[Callable[[PyTree, Array], float]] = None,
+    ) -> Tuple[PyTree, Array]:
+    """Estimate threshold for High Probability Region of approximate posterior"""
+    samples, _ = prior_fn(
+        key,
+        n=n,
+        n_samples=1,
+    )
+
+    theta_template = tree.map(
+        lambda leaf: jnp.zeros(
+            (n_batch,) + leaf.shape[1:]
+        ),
+        samples
+    )
+    y_expanded = tree.map(
+        lambda leaf: jnp.broadcast_to(
+            leaf,
+            (n_batch,) + leaf.shape[1:]
+        ),
+        y_obs
+    )
+
+    _, decoder = Tokens.from_pytree_with_decoder(
+        {**y_expanded, **theta_template},
+        condition=list(y_expanded.keys()),
+        labeller=labeller,
+        sample_ndims=1,
+        functional_inputs=f_in,
+    )
+
+    n_sampled: int = 0
+    all_tokens = None
+    log_prob = jnp.array([])
+
+    while True:
+        print(f'progress: {n_sampled} of {n_total}')
+        print(f'sampling {n_batch}')
+
+        prior_samples, _ = prior_fn(
+            key,
+            n=n,
+            n_samples=n_batch,
+        )
+        output_tokens = Tokens.from_pytree(
+            {**y_expanded, **prior_samples},
+            condition=list(y_expanded.keys()),
+            labeller=labeller,
+            sample_ndims=1,
+            functional_inputs=f_in,
+        )
+        new_log_prob = model.log_prob_posterior_samples(output_tokens)
+
+        print(f'new_log_prob: {new_log_prob}')
+        print(f'new_log_prob shape: {new_log_prob.shape}')
+
+        if prob_transform is not None:
+            new_log_prob = prob_transform(decoder(output_tokens), new_log_prob)
+
+        print(f'new_log_prob (post transform): {new_log_prob}')
+
+        log_prob = jnp.concatenate([log_prob, new_log_prob])
+
+        if all_tokens is None:
+            all_tokens = output_tokens
+        else:
+            all_tokens = tree.map(
+                lambda x, y: jnp.concatenate([x, y]),
+                all_tokens,
+                output_tokens
+            )
+
+        n_sampled += n_batch
+
+        if n_sampled >= n_total:
+            break
+
+    values = decoder(all_tokens)
+    values = {
+        k: v
+        for k, v in values.items()
+        if k in theta_template.keys()
+    }
+
+    return values, log_prob

--- a/tfmpe/estimators/proposals.py
+++ b/tfmpe/estimators/proposals.py
@@ -15,7 +15,7 @@ def truncated_proposal_rejection(
     n_samples: int,
     epsilon: float,
     y_obs: Dict[str, Array],
-    prior_fn: Callable,
+    prior_fn: Callable[[PyTree, int, int, dict], dict],
     n: int,
     prior_log_prob: Callable[[PyTree], float],
     prob_transform: Optional[Callable[[PyTree, Array], float]] = None,
@@ -88,7 +88,7 @@ def truncated_proposal_sir(
     key: Array,
     model: TFMPE,
     labeller: Labeller,
-    f_in: Dict[str, Array],
+    f_in: Optional[Dict[str, Array]],
     n_samples: int,
     epsilon: float,
     y_obs: Dict[str, Array],
@@ -156,16 +156,17 @@ def _batch_sample(
     prior_fn: Callable,
     n: int,
     y_obs: Dict[str, Array],
-    f_in: Dict[str, Array],
+    f_in: Optional[Dict[str, Array]],
     n_batch: int,
     n_total: int,
     prob_transform: Optional[Callable[[PyTree, Array], float]] = None,
     ) -> Tuple[PyTree, Array]:
     """Estimate threshold for High Probability Region of approximate posterior"""
-    samples, _ = prior_fn(
+    samples = prior_fn(
         key,
-        n=n,
-        n_samples=1,
+        n,
+        1,
+        f_in
     )
 
     theta_template = tree.map(
@@ -249,8 +250,9 @@ def _batch_sample_prior(
     """Estimate threshold for High Probability Region of approximate posterior"""
     samples, _ = prior_fn(
         key,
-        n=n,
-        n_samples=1,
+        n,
+        1,
+        f_in
     )
 
     theta_template = tree.map(
@@ -283,10 +285,11 @@ def _batch_sample_prior(
         print(f'progress: {n_sampled} of {n_total}')
         print(f'sampling {n_batch}')
 
-        prior_samples, _ = prior_fn(
+        prior_samples = prior_fn(
             key,
-            n=n,
-            n_samples=n_batch,
+            n,
+            n_batch,
+            f_in
         )
         output_tokens = Tokens.from_pytree(
             {**y_expanded, **prior_samples},

--- a/tfmpe/estimators/tfmpe.py
+++ b/tfmpe/estimators/tfmpe.py
@@ -276,6 +276,7 @@ class TFMPE(nnx.Module):
             partition_idx=source_samples.partition_idx,
             padding_mask=None if source_samples.padding_mask is None else 0,#type: ignore
             functional_inputs=None if source_samples.functional_inputs is None else 0,#type: ignore
+            group_id=0,#type: ignore
         )
 
         def solve_params(tokens):

--- a/tfmpe/estimators/tfmpe.py
+++ b/tfmpe/estimators/tfmpe.py
@@ -216,24 +216,43 @@ class TFMPE(nnx.Module):
         tokens: Tokens,
         batch_size: int
     ) -> Tokens:
-        samples = []
         target = tokens.sample_shape[0]
-        def process_batch(i) -> Tokens:
-            batch = jax.tree.map(
-                lambda leaf: leaf[i:i+batch_size],
-                tokens
+
+        # Pad first axis so it divides evenly into batches
+        remainder = target % batch_size
+        if remainder != 0:
+            pad_size = batch_size - remainder
+            tokens = jax.tree.map(
+                lambda leaf: jnp.pad(
+                    leaf,
+                    [(0, pad_size)]
+                    + [(0, 0)] * (leaf.ndim - 1),
+                ),
+                tokens,
             )
-            return self.sample_posterior(batch)
 
-        samples = [
-            process_batch(i)
-            for i
-            in range(0, target, batch_size)
-        ]
+        n_batches = -(-target // batch_size)
 
-        return dataclasses.replace(
+        # Reshape to (n_batches, batch_size, ...)
+        batched = jax.tree.map(
+            lambda leaf: leaf.reshape(
+                (n_batches, batch_size) + leaf.shape[1:]
+            ),
             tokens,
-            data=jnp.concatenate([s.data for s in samples])
+        )
+
+        def scan_fn(estimator, batch):
+            result = estimator.sample_posterior(batch)
+            return estimator, result
+
+        _, results = nnx.scan(scan_fn)(self, batched)
+
+        # Flatten back to (n_batches * batch_size, ...) and trim
+        return jax.tree.map(
+            lambda leaf: leaf.reshape(
+                (-1,) + leaf.shape[2:]
+            )[:target],
+            results,
         )
 
     def sample_posterior(

--- a/tfmpe/estimators/tfmpe.py
+++ b/tfmpe/estimators/tfmpe.py
@@ -1,0 +1,367 @@
+"""Tokenized Flow Matching Posterior Estimator (TFMPE)."""
+
+from typing import Optional, Protocol
+
+import diffrax
+import jax
+import jax.numpy as jnp
+import dataclasses
+from flax import nnx
+from jaxtyping import Array
+
+from ..preprocessing.tokens import Tokens
+from .ode import (
+    solve_forward_ode,
+    solve_augmented_ode
+)
+
+class TokenisedVectorField(Protocol):
+    """Protocol for vector field networks on tokenised data.
+
+    A vector field network maps (context, params, time) -> velocity.
+    Must be callable (typically an nnx.Module) to work with NNX
+    transformations.
+    """
+
+    def __call__(
+        self, tokens: Tokens, time: Array
+    ) -> Array:
+        """Compute velocity for flow matching.
+
+        Parameters
+        ----------
+        tokens: Tokens
+            Tokens to compute vector fields for
+        time : Array
+            Time points, shape (batch,) or scalar
+
+        Returns
+        -------
+        Array
+            Velocity prediction, same shape as params.data
+        """
+        ...
+
+
+class BaseDistribution(Protocol):
+    """Protocol for base distributions in flow matching.
+
+    A base distribution must support sampling and log probability
+    evaluation. Sampling is stateful and managed by nnx.Rngs.
+    """
+
+    def sample(self, shape: tuple) -> Array:
+        """Sample from the base distribution.
+
+        Parameters
+        ----------
+        shape : tuple
+            Shape of samples to generate
+
+        Returns
+        -------
+        Array
+            Samples with given shape
+        """
+        ...
+
+    def log_prob(self, x: Array) -> Array:
+        """Compute log probability of the base distribution.
+
+        Parameters
+        ----------
+        x : Array
+            Values to evaluate
+
+        Returns
+        -------
+        Array
+            Log probabilities
+        """
+        ...
+
+
+class NormalDistribution(nnx.Module):
+    """Standard normal distribution base distribution.
+
+    Provides sample() and log_prob() methods for base distribution
+    in flow matching. Implemented as nnx.Module for JAX compilation
+    compatibility.
+
+    Attributes
+    ----------
+    rngs : nnx.Rngs
+        RNG streams for stochastic sampling
+    """
+
+    def __init__(self, rngs: nnx.Rngs) -> None:
+        """Initialize NormalDistribution with RNG streams.
+
+        Parameters
+        ----------
+        rngs : nnx.Rngs
+            RNG streams for sampling. Will use default stream
+            accessed via rngs() or rngs.params()
+        """
+        self.rngs = rngs
+
+    def sample(self, shape: tuple) -> Array:
+        """Sample from standard normal distribution.
+
+        Parameters
+        ----------
+        shape : tuple
+            Shape of samples to generate
+
+        Returns
+        -------
+        Array
+            Samples from N(0, I) with given shape
+        """
+        rng = self.rngs.params()
+        return jax.random.normal(rng, shape)
+
+    def log_prob(self, x: Array) -> Array:
+        """Compute log probability of standard normal.
+
+        Parameters
+        ----------
+        x : Array
+            Values to evaluate
+
+        Returns
+        -------
+        Array
+            Sum of log probabilities over all dimensions
+        """
+        return jnp.sum(jax.scipy.stats.norm.logpdf(x))
+
+
+class TFMPE(nnx.Module):
+    """Unified estimator for sampling and log probability computation.
+
+    Combines ODE solving for forward (sampling) and backward
+    (log probability) trajectories using a trained vector field
+    network.
+
+    Attributes
+    ----------
+    vf_network : TokenisedVectorField
+        Vector field network f(context, params, t) -> Array.
+        Must be an nnx.Module so its state (including RNG
+        streams) is properly managed during transformations.
+    base_dist : nnx.Module
+        Base distribution with sample(shape) and
+        log_prob(x) methods
+    solver : diffrax solver instance
+        ODE solver (default: Dopri5())
+    ode_kwargs : dict
+        ODE solver options (rtol, atol)
+    """
+
+    vf_network: TokenisedVectorField
+    base_dist: BaseDistribution
+
+    def __init__(
+        self,
+        vf_network: TokenisedVectorField,
+        base_dist: BaseDistribution,
+        solver=None,
+        ode_kwargs: Optional[dict] = None,
+    ) -> None:
+        """Initialize TFMPE.
+
+        Parameters
+        ----------
+        vf_network : TokenisedVectorField
+            Vector field network f(context, params, t) -> Array.
+            Must be an nnx.Module so its state is captured and
+            RNG streams are properly managed during training.
+        base_dist : BaseDistribution
+            Base distribution with sample(shape) and
+            log_prob(x) methods. Example: NormalDistribution(rngs)
+        solver : diffrax solver, optional
+            ODE solver instance. Default: Heun()
+        ode_kwargs : dict, optional
+            ODE solver options with keys:
+            - 'rtol': relative tolerance (default: 1e-5)
+            - 'atol': absolute tolerance (default: 1e-5)
+        """
+        self.vf_network = vf_network
+        self.base_dist = base_dist
+        self.solver = solver if solver is not None else (
+            diffrax.Dopri5()
+        )
+
+        # Set ODE solver parameters
+        if ode_kwargs is None:
+            ode_kwargs = {}
+        self.ode_kwargs = {
+            "rtol": ode_kwargs.get("rtol", 1e-5),
+            "atol": ode_kwargs.get("atol", 1e-5),
+        }
+
+        # Validate ODE parameters
+        if self.ode_kwargs["rtol"] <= 0 or (
+            self.ode_kwargs["atol"] <= 0
+        ):
+            raise ValueError(
+                "ODE tolerances must be positive. "
+                f"Got rtol={self.ode_kwargs['rtol']}, "
+                f"atol={self.ode_kwargs['atol']}"
+            )
+
+    def sample_posterior_batched(
+        self,
+        tokens: Tokens,
+        batch_size: int
+    ) -> Tokens:
+        samples = []
+        target = tokens.sample_shape[0]
+        def process_batch(i) -> Tokens:
+            batch = jax.tree.map(
+                lambda leaf: leaf[i:i+batch_size],
+                tokens
+            )
+            return self.sample_posterior(batch)
+
+        samples = [
+            process_batch(i)
+            for i
+            in range(0, target, batch_size)
+        ]
+
+        return dataclasses.replace(
+            tokens,
+            data=jnp.concatenate([s.data for s in samples])
+        )
+
+    def sample_posterior(
+        self,
+        tokens: Tokens
+    ) -> Tokens:
+        """Generate posterior samples via forward ODE solving.
+
+        Samples from base distribution into params.data and solves
+        forward ODE from t=0 to t=1 using the vector field network.
+
+        Parameters
+        ----------
+        tokens: Tokens
+            parameter and observation tokens
+
+        Returns
+        -------
+        Tokens
+            Posterior samples with same structure metadata as params
+        """
+        # Sample from base distribution into params.data
+        target_n_tokens = tokens.data.shape[tokens.sample_ndims] - tokens.partition_idx
+        target_shape = tokens.sample_shape + (target_n_tokens, tokens.data.shape[-1])
+        source_data = tokens.data.at[:, tokens.partition_idx:].set(
+            self.base_dist.sample(target_shape)
+        )
+        source_samples = dataclasses.replace(
+            tokens,
+            data=source_data
+        )
+
+        vf_fn = _make_stateless(self.vf_network)
+
+        param_axes = Tokens(
+            data=0, #type: ignore
+            labels=0,#type: ignore
+            position=0,#type: ignore
+            condition=0,#type: ignore
+            partition_idx=source_samples.partition_idx,
+            padding_mask=None if source_samples.padding_mask is None else 0,#type: ignore
+            functional_inputs=None if source_samples.functional_inputs is None else 0,#type: ignore
+        )
+
+        def solve_params(tokens):
+            # Solve forward ODE using ODE helper
+            output_tokens = solve_forward_ode(
+                vf_fn=vf_fn,
+                tokens=tokens,
+                solver=self.solver,
+                rtol=self.ode_kwargs["rtol"],
+                atol=self.ode_kwargs["atol"],
+            )
+            return output_tokens
+
+
+        return jax.vmap(
+            solve_params,
+            in_axes=[param_axes]
+        )(source_samples)
+
+    def log_prob_posterior_samples(
+        self,
+        tokens: Tokens,
+        n_epsilon: int = 10,
+    ) -> Array:
+        """Compute log probabilities for posterior samples.
+
+        Uses FFJORD algorithm with augmented backward ODE solving
+        and stochastic trace estimation.
+
+        Parameters
+        ----------
+        theta : Tokens
+            Posterior samples to evaluate
+        context : Tokens
+            Context tokens
+        n_epsilon : int, optional
+            Number of Hutchinson trace samples (default: 10)
+
+        Returns
+        -------
+        Array
+            Log probability scalar
+        """
+        # Solve augmented ODE to get trace-based log determinant
+        rng = jax.random.PRNGKey(0)
+
+        def solve_log_prob(tokens):
+            theta_tokens, log_det = solve_augmented_ode(
+                vf_fn=_make_stateless(self.vf_network),
+                tokens=tokens,
+                solver=self.solver,
+                rng=rng,
+                rtol=self.ode_kwargs["rtol"],
+                atol=self.ode_kwargs["atol"],
+                n_epsilon=n_epsilon,
+            )
+            return theta_tokens, log_det
+
+        theta_tokens, log_det = jax.vmap(
+            solve_log_prob,
+        )(tokens)
+
+        # Compute log probability of base distribution
+        log_prob_base = self.base_dist.log_prob(
+            theta_tokens.data[:, theta_tokens.partition_idx:]
+        )
+
+        # Total log probability
+        log_prob = log_prob_base + log_det
+
+        return log_prob
+
+def _make_stateless(model: TokenisedVectorField) -> TokenisedVectorField:
+    if isinstance(model, nnx.Module):
+        graphdef, state = nnx.split(model)
+        state_flat, state_treedef = jax.tree.flatten(state)
+
+        def stateless_vf_fn(
+            tokens: Tokens, time: Array
+        ) -> Array:
+            rebuilt_state = state_treedef.unflatten(state_flat)
+            model = nnx.merge(graphdef, rebuilt_state)
+            model.eval()
+            vf = model(tokens, time)
+            return vf
+
+        return stateless_vf_fn
+
+    return model

--- a/tfmpe/estimators/training.py
+++ b/tfmpe/estimators/training.py
@@ -102,7 +102,7 @@ def fit_bottom_up(
     labeller: Labeller,
     prior_log_prob: Callable[[PyTree], float],
     prob_transform: Optional[Callable] = None,
-    obs_f_in: Dict = {},
+    obs_f_in: Optional[Dict] = None,
     f_in_fn: Optional[Callable]=None,
     f_in_args: list=[],
     f_in_args_global: list=[],
@@ -192,7 +192,8 @@ def fit_bottom_up(
     rng, key_sim = jax.random.split(rng)
 
     r = 0
-    all_train_tokens = None
+    like_train_tokens = None
+
     while r < n_rounds:
         if isinstance(tfmpe, list) and isinstance(opt, list):
             tfmpe_local, tfmpe_global = tfmpe
@@ -252,15 +253,26 @@ def fit_bottom_up(
             y = simulator_fn(key_sim, theta, 1, obs_f_in)
 
         # Learn local likelihood
-        like_train_tokens = Tokens.from_pytree(
-            {**y, **theta},
-            condition=list(theta.keys()),
-            labeller=labeller,
-            sample_ndims=1,
-            functional_inputs=f_in
-        )
-
-        all_train_tokens = like_train_tokens
+        if like_train_tokens is None:
+            like_train_tokens = Tokens.from_pytree(
+                {**y, **theta},
+                condition=list(theta.keys()),
+                labeller=labeller,
+                sample_ndims=1,
+                functional_inputs=f_in
+            )
+        else:
+            new_like_train_tokens = Tokens.from_pytree(
+                {**y, **theta},
+                condition=list(theta.keys()),
+                labeller=labeller,
+                sample_ndims=1,
+                functional_inputs=f_in
+            )
+            like_train_tokens = combine_tokens(
+                new_like_train_tokens,
+                like_train_tokens
+            )
 
         # Create validation tokens
         if f_in_fn is not None:
@@ -410,12 +422,10 @@ def fit_bottom_up(
         )
 
         if isinstance(tfmpe, TFMPE):
-            all_train_tokens = combine_tokens(
+            global_train_tokens = combine_tokens(
                 like_train_tokens,
                 global_train_tokens
             )
-        else:
-            all_train_tokens = global_train_tokens
 
         # Train global posterior
         # Create validation tokens for second fit
@@ -448,7 +458,7 @@ def fit_bottom_up(
         print('fit_memory_efficient')
         tfmpe_global, second_losses = fit_memory_efficient(
             model=tfmpe_global,
-            train=all_train_tokens,
+            train=global_train_tokens,
             val=val_tokens,
             loss=_cfm_loss,
             opt=global_opt,

--- a/tfmpe/estimators/training.py
+++ b/tfmpe/estimators/training.py
@@ -1,0 +1,614 @@
+"""Training loops for TFMPE models.
+
+Provides speed-optimized and memory-efficient training implementations.
+"""
+
+from typing import Callable, Dict, List, Tuple, Optional
+from math import prod
+
+import jax
+from jax import tree, numpy as jnp
+from flax import nnx
+from jaxtyping import Array, PRNGKeyArray, PyTree
+
+from .tfmpe import TFMPE
+from .proposals import truncated_proposal_sir
+from ..preprocessing.tokens import Tokens
+from ..preprocessing.combine import combine_tokens
+from ..preprocessing.utils import Labeller
+from ..nn.training import fit_memory_efficient
+
+import dataclasses
+
+def _cfm_loss(
+    tfmpe: TFMPE,
+    tokens: Tokens,
+    rng: Array,
+) -> Array:
+    """Continuous Flow Matching loss with batched inputs.
+
+    Computes CFM loss for batched inputs with leading batch
+    dimension. Returns scalar loss averaged over batch.
+
+    Parameters
+    ----------
+    tfmpe : TFMPE
+        TFMPE model instance
+    tokens: Tokens
+        Tokens to compute loss over
+    time : Array
+        Time points for batch. Shape: (batch,)
+
+    Returns
+    -------
+    Array
+        Scalar loss (averaged over batch)
+    """
+    sigma_min = 0.001
+    theta_data = tokens.data[:, tokens.partition_idx:]
+
+    # Sample from base distribution
+    theta_0 = tfmpe.base_dist.sample(theta_data.shape)
+
+    # Reshape time for broadcasting: (batch,) -> (batch, 1, 1)
+    # theta_data shape: (batch, n_tokens, token_dim)
+    time = jax.random.uniform(rng, (tokens.data.shape[0],))
+    time_bc = time[:, None, None]
+
+    # Compute flow path interpolation
+    sigma_t = 1.0 - (1.0 - sigma_min) * time_bc
+    theta_t = theta_0 * sigma_t + theta_data * time_bc
+
+    # Compute target velocity
+    # u_t = (theta - (1 - sigma_min) * theta_t) / (1 - sigma_t)
+    numerator = theta_data - (1.0 - sigma_min) * theta_t
+    denominator = 1.0 - (1.0 - sigma_min) * time_bc
+    u_target = numerator / denominator
+
+    # Set theta.data to interpolated values and evaluate vf
+    new_data = tokens.data.at[:, tokens.partition_idx:].set(theta_t)
+    theta_t_tokens = dataclasses.replace(tokens, data = new_data)
+    v_pred = tfmpe.vf_network(
+        theta_t_tokens,
+        time
+    )
+
+    if tokens.padding_mask is not None:
+        theta_padding_mask = tokens.padding_mask[:,tokens.partition_idx:,None]
+        return jnp.sum(
+            jnp.square(v_pred - u_target) * theta_padding_mask
+        ) / jnp.sum(theta_padding_mask)
+
+    return jnp.mean(
+        jnp.square(v_pred - u_target)
+    )
+
+
+def fit_bottom_up(
+    tfmpe: TFMPE | List[TFMPE],
+    y_obs: Dict[str, Array],
+    simulator_fn: Callable,
+    prior_fn: Callable,
+    local_fn: Callable,
+    global_names: List[str],
+    n_groups: int,
+    n_rounds: int,
+    n_samples_per_round: int,
+    n_val_samples: int,
+    opt: nnx.Optimizer | List[nnx.Optimizer],
+    n_iter_per_round: int,
+    batch_size: int,
+    rng: PRNGKeyArray,
+    labeller: Labeller,
+    prior_log_prob: Callable[[PyTree], float],
+    prob_transform: Optional[Callable] = None,
+    obs_f_in: Dict = {},
+    f_in_fn: Optional[Callable]=None,
+    f_in_args: list=[],
+    f_in_args_global: list=[],
+    epsilon: float = 1e-3
+) -> Tuple[TFMPE, List[Tuple[Array, Array, Array, Array]]]:
+    """Multi-round bottom-up training algorithm.
+
+    Each round alternates between local likelihood training
+    (n=1 local groups) and global posterior training
+    (n=n_groups local groups).
+
+    Currently only supports n_rounds=1. Each round makes two
+    fit_memory_efficient() calls:
+    1. Train p(y|theta) with n=1 local parameters
+    2. Train p(theta,z|y) with n=n_groups local parameters
+
+    This is a non-jittable wrapper using fit_memory_efficient() internally
+    for each training step.
+
+    Parameters
+    ----------
+    tfmpe : TFMPE
+        TFMPE model to train
+    y_obs : Dict[str, Array]
+        Observed data with keys matching simulator output
+    simulator_fn : Callable
+        Function: (rng, params_dict, n) -> observations_dict
+    prior_fn : Callable
+        Function: (rng, n, n_samples) -> parameters_dict
+    local_fn : Callable
+        Function: (rng, global_samples, n) -> local_params_dict
+    global_names : List[str]
+        Names of global parameters (non-local)
+    n_groups : int
+        Number of local groups in full hierarchical model
+    n_rounds : int
+        Number of training rounds (currently only 1 supported)
+    n_samples_per_round : int
+        Number of parameter samples per round
+    n_val_samples : int
+        Number of validation samples
+    opt : nnx.Optimizer
+        NNX optimizer instance (pre-initialized with tfmpe)
+    n_iter_per_round : int
+        Training iterations per round
+    batch_size : int
+        Number of samples per batch for fit_memory_efficient calls
+    rng : PRNGKeyArray
+        PRNG key for sampling
+    independence : Independence
+        Independence structure for token creation
+    labeller : Labeller
+        Labeller instance with label mapping for all parameter and
+        observation keys. Must include all possible keys from prior_fn,
+        simulator_fn, and local_fn outputs.
+
+    Returns
+    -------
+    Tuple[TFMPE, List[Tuple[Array, Array, Array, Array]]]
+        Trained TFMPE and list of 4-tuples (train_loss_local,
+        val_loss_local, train_loss_global, val_loss_global),
+        one per round, where each loss array has shape
+        (n_iter_per_round,)
+
+    Raises
+    ------
+    ValueError
+        If n_rounds < 1
+    NotImplementedError
+        If n_rounds > 1
+
+    Notes
+    -----
+    - Not jittable: uses Python loop over rounds
+    - Currently only n_rounds=1 is implemented
+    - Each round makes TWO fit_memory_efficient() calls
+    - Parameter progression: n=1 local → n=n_groups local
+    - Return value: 4-tuple of losses per round (local & global)
+    """
+    # Validate inputs
+    if n_rounds < 1:
+        raise ValueError("n_rounds must be >= 1")
+
+    all_losses = []
+
+    rng, key_prior = jax.random.split(rng)
+    rng, key_sim = jax.random.split(rng)
+
+    r = 0
+    all_train_tokens = None
+    while r < n_rounds:
+        if isinstance(tfmpe, list) and isinstance(opt, list):
+            tfmpe_local, tfmpe_global = tfmpe
+            local_opt, global_opt = opt
+        elif isinstance(tfmpe, TFMPE) and isinstance(opt, nnx.Optimizer):
+            tfmpe_local, tfmpe_global = tfmpe, tfmpe
+            local_opt, global_opt = opt, opt
+        else:
+            raise ValueError("models and opt need to match")
+
+        # Compute proposal
+        if r == 0:
+            # Sample theta_local from prior with n=1
+            if f_in_fn is not None:
+                rng, key_f_in = jax.random.split(rng)
+                f_in = f_in_fn(key_f_in, n_samples_per_round, *f_in_args)
+            else:
+                f_in = None
+
+            theta = prior_fn(
+                key_prior,
+                1,
+                n_samples_per_round,
+                f_in
+            )
+
+            # Simulate observations
+            y = simulator_fn(key_sim, theta, 1, f_in)
+        else:
+            rng, key_prop = jax.random.split(rng)
+            theta = truncated_proposal_sir(
+                key_prop,
+                tfmpe_global,
+                labeller,
+                obs_f_in,
+                n_samples_per_round,
+                epsilon,
+                y_obs,
+                prior_fn,
+                n_groups,
+                prior_log_prob,
+                prob_transform,
+                n_batch=1_000,
+                n_estimate=1_000,
+            )
+            theta_local = tree.map(
+                lambda leaf: leaf[:, :1],
+                {k: v for k, v in theta.items() if k not in global_names}
+            )
+            theta_global = {
+                k: v
+                for k, v in theta.items()
+                if k in global_names
+            }
+            theta = {**theta_global, **theta_local}
+            f_in = obs_f_in
+            y = simulator_fn(key_sim, theta, 1, obs_f_in)
+
+        # Learn local likelihood
+        like_train_tokens = Tokens.from_pytree(
+            {**y, **theta},
+            condition=list(theta.keys()),
+            labeller=labeller,
+            sample_ndims=1,
+            functional_inputs=f_in
+        )
+
+        all_train_tokens = like_train_tokens
+
+        # Create validation tokens
+        if f_in_fn is not None:
+            rng, key_f_in = jax.random.split(rng)
+            val_f_in = f_in_fn(key_f_in, n_val_samples, *f_in_args)
+        else:
+            val_f_in = None
+
+        rng, key_val_prior = jax.random.split(rng)
+        rng, key_val_sim = jax.random.split(rng)
+        val_theta = prior_fn(
+            key_val_prior,
+            1,
+            n_val_samples,
+            val_f_in
+        )
+        val_y = simulator_fn(
+            key_val_sim,
+            val_theta,
+            1,
+            val_f_in
+        )
+
+        val_tokens = Tokens.from_pytree(
+            {**val_y, **val_theta},
+            condition=list(val_theta.keys()),
+            labeller=labeller,
+            sample_ndims=1,
+            functional_inputs=val_f_in
+        )
+        print('fitting to theta')
+
+        # First fit_fast: p(y|theta) with n=1
+        tfmpe_local.train()
+        rng, key_fit = jax.random.split(rng)
+        tfmpe_local, first_losses = fit_memory_efficient(
+            model=tfmpe_local,
+            train=like_train_tokens,
+            val=val_tokens,
+            opt=local_opt,
+            loss=_cfm_loss,
+            n_iter=n_iter_per_round,
+            batch_size=batch_size,
+            rng=key_fit,
+            patience=100,
+            delta=1e-3
+        )
+        train_loss_local, val_loss_local = first_losses
+        print("train_loss_local", train_loss_local)
+        print("val_loss_local", val_loss_local)
+
+        # Extract globals and expand to n=n_groups
+        if f_in_fn is not None:
+            rng, key_local_f_in, key_val_f_in = jax.random.split(rng, 3)
+            f_in = f_in_fn(
+                key_local_f_in,
+                n_samples_per_round,
+                *f_in_args_global
+            )
+            val_f_in = f_in_fn(
+                key_val_f_in,
+                n_val_samples,
+                *f_in_args_global
+            )
+            f_in_local = {
+                k: v.reshape(
+                    (prod(v.shape[:2]), 1) + v.shape[2:]
+                )
+                for k, v in f_in.items()
+                if k not in global_names
+            }
+            f_in_global = {
+                k: jnp.repeat(v, n_groups, 0)
+                for k, v in f_in.items()
+                if k in global_names
+            }
+            f_in_reshaped = {
+                **f_in_global,
+                **f_in_local
+            }
+        else:
+            f_in_reshaped = None
+            val_f_in = None
+
+        theta_global = {k: v for k, v in theta.items() if k in global_names}
+        rng, key_local = jax.random.split(rng)
+        theta_local = local_fn(
+            key_local,
+            theta_global,
+            n_groups,
+            f_in
+        )
+        single_theta_local = tree.map(
+            lambda leaf: leaf.reshape(
+                (prod(leaf.shape[:2]), 1) + leaf.shape[2:]
+            ), # (n_samples, n_groups, n_events, n_batch) -> (n_samples * n_groups, 1, n_events, n_batch)
+            theta_local
+        )
+        single_theta_global = tree.map(
+            lambda leaf: jnp.repeat(leaf, n_groups, 0), # (n_samples, n_events, n_batch) -> (n_samples * n_groups, n_events, n_batch)
+            theta_global
+        )
+
+        single_theta_n = {**single_theta_global, **single_theta_local}
+
+        # Create param template for sampling with n=n_groups structure
+        y_template = tree.map(
+            lambda leaf: jnp.zeros(
+                (leaf.shape[0] * n_groups, 1) + leaf.shape[2:]
+            ),
+            y
+        )
+
+        tokens, decoder = Tokens.from_pytree_with_decoder(
+            {**y_template, **single_theta_n},
+            condition=list(single_theta_n.keys()),
+            labeller=labeller,
+            sample_ndims=1,
+            functional_inputs=f_in_reshaped,
+        )
+
+        print('sampling y_n')
+
+        y_n = tfmpe_local.sample_posterior_batched(
+            tokens,
+            batch_size=10_000
+        )
+
+        # Create training tokens for second fit
+        theta_n = {**theta_global, **theta_local}
+
+        decoded_y_n = decoder(y_n)
+        decoded_y_n = {k: v for k, v in decoded_y_n.items() if k in y.keys()}
+        y_n_reshaped = tree.map(
+            lambda leaf: leaf.reshape(
+                (leaf.shape[0] // n_groups, n_groups) + leaf.shape[2:]
+            ),
+            decoded_y_n
+        )
+
+        global_train_tokens = Tokens.from_pytree(
+            {**theta_n, **y_n_reshaped},
+            condition=list(y_n_reshaped.keys()),
+            labeller=labeller,
+            sample_ndims=1,
+            functional_inputs=f_in
+        )
+
+        if isinstance(tfmpe, TFMPE):
+            all_train_tokens = combine_tokens(
+                like_train_tokens,
+                global_train_tokens
+            )
+        else:
+            all_train_tokens = global_train_tokens
+
+        # Train global posterior
+        # Create validation tokens for second fit
+        rng, key_val_prior = jax.random.split(rng)
+        rng, key_val_sim = jax.random.split(rng)
+        val_theta = prior_fn(
+            key_val_prior,
+            n_groups,
+            n_val_samples,
+            val_f_in
+        )
+        val_y = simulator_fn(
+            key_val_sim,
+            val_theta,
+            n_groups,
+            val_f_in
+        )
+
+        val_tokens = Tokens.from_pytree(
+            {**val_theta, **val_y},
+            condition=list(val_y.keys()),
+            labeller=labeller,
+            sample_ndims=1,
+            functional_inputs=val_f_in
+        )
+
+        # Second fit_fast (back to training mode)
+        tfmpe_global.train()
+        rng, key_fit = jax.random.split(rng)
+        print('fit_memory_efficient')
+        tfmpe_global, second_losses = fit_memory_efficient(
+            model=tfmpe_global,
+            train=all_train_tokens,
+            val=val_tokens,
+            loss=_cfm_loss,
+            opt=global_opt,
+            n_iter=n_iter_per_round,
+            batch_size=batch_size,
+            rng=key_fit,
+            patience=100,
+            delta=1e-3
+        )
+        train_loss_global, val_loss_global = second_losses
+
+        # Append 4-tuple of losses
+        all_losses.append((
+            train_loss_local,
+            val_loss_local,
+            train_loss_global,
+            val_loss_global,
+        ))
+
+        r += 1
+
+    if isinstance(tfmpe, list):
+        return tfmpe[1], all_losses
+
+    return tfmpe, all_losses
+
+def fit_directly(
+    tfmpe: TFMPE,
+    simulator_fn: Callable,
+    prior_fn: Callable,
+    n_groups: int,
+    n_samples_per_round: int,
+    n_val_samples: int,
+    opt: nnx.Optimizer,
+    n_iter_per_round: int,
+    batch_size: int,
+    rng: PRNGKeyArray,
+    labeller: Labeller,
+    f_in_fn: Optional[Callable] = None,
+    f_in_args: list = [],
+    delta: float = 0.0,
+    patience: int = 0,
+) -> Tuple[TFMPE, Tuple[Array, Array]]:
+    """Version of fit_bottom_up which fits the global estimator directly.
+
+    Parameters
+    ----------
+    tfmpe : TFMPE
+        TFMPE model to train
+    simulator_fn : Callable
+        Function: (rng, params_dict, n, f_in) -> observations_dict
+    prior_fn : Callable
+        Function: (rng, n, n_samples, f_in) -> parameters_dict
+    n_groups : int
+        Number of local groups in full hierarchical model
+    n_samples_per_round : int
+        Number of parameter samples per round
+    n_val_samples : int
+        Number of validation samples
+    opt : nnx.Optimizer
+        NNX optimizer instance (pre-initialized with tfmpe)
+    n_iter_per_round : int
+        Training iterations per round
+    batch_size : int
+        Number of samples per batch for fit_memory_efficient calls
+    rng : PRNGKeyArray
+        PRNG key for sampling
+    independence : Independence
+        Independence structure for token creation
+    labeller : Labeller
+        Labeller instance with label mapping for all parameter and
+        observation keys.
+    f_in_fn : Callable, optional
+        Function to generate functional inputs: (rng, n_samples, *f_in_args) -> f_in_dict
+    f_in_args : list, optional
+        Additional arguments for f_in_fn
+    delta : float, optional
+        Minimum improvement in training loss to reset patience counter.
+        Default is 0.0 (any improvement counts).
+    patience : int, optional
+        Number of epochs to wait for improvement before stopping.
+        Set to 0 to disable early stopping. Default is 0.
+
+    Returns
+    -------
+    Tuple[TFMPE, Tuple[Array, Array]]
+        Trained TFMPE and tuple of (train_losses, val_losses)
+    """
+    rng, key_prior = jax.random.split(rng)
+    rng, key_sim = jax.random.split(rng)
+
+    # Generate functional inputs if provided
+    if f_in_fn is not None:
+        rng, key_f_in = jax.random.split(rng)
+        f_in = f_in_fn(key_f_in, n_samples_per_round, *f_in_args)
+    else:
+        f_in = None
+
+    # Sample theta from prior
+    theta = prior_fn(
+        key_prior,
+        n_groups,
+        n_samples_per_round,
+        f_in
+    )
+
+    # Simulate observations
+    y = simulator_fn(key_sim, theta, n_groups, f_in)
+
+    # Create training tokens combining y and theta with condition
+    train_tokens = Tokens.from_pytree(
+        {**y, **theta},
+        condition=list(y.keys()),
+        labeller=labeller,
+        sample_ndims=1,
+        functional_inputs=f_in
+    )
+
+    # Create validation tokens
+    if f_in_fn is not None:
+        rng, key_val_f_in = jax.random.split(rng)
+        val_f_in = f_in_fn(key_val_f_in, n_val_samples, *f_in_args)
+    else:
+        val_f_in = None
+
+    rng, key_val_prior = jax.random.split(rng)
+    rng, key_val_sim = jax.random.split(rng)
+    val_theta = prior_fn(
+        key_val_prior,
+        n_groups,
+        n_val_samples,
+        val_f_in
+    )
+    val_y = simulator_fn(key_val_sim, val_theta, n_groups, val_f_in)
+
+    val_tokens = Tokens.from_pytree(
+        {**val_y, **val_theta},
+        condition=list(val_y.keys()),
+        labeller=labeller,
+        sample_ndims=1,
+        functional_inputs=val_f_in
+    )
+
+    # Fit p(theta|y) with n=n_groups
+    tfmpe.train()
+    rng, key_fit = jax.random.split(rng)
+    tfmpe, losses = fit_memory_efficient(
+        model=tfmpe,
+        train=train_tokens,
+        val=val_tokens,
+        opt=opt,
+        loss=_cfm_loss,
+        n_iter=n_iter_per_round,
+        batch_size=batch_size,
+        rng=key_fit,
+        delta=delta,
+        patience=patience
+    )
+    train_loss, val_loss = losses
+    print("train_loss", train_loss)
+    print("val_loss", val_loss)
+
+    return tfmpe, (train_loss, val_loss)

--- a/tfmpe/estimators/training/__init__.py
+++ b/tfmpe/estimators/training/__init__.py
@@ -3,17 +3,18 @@
 Provides speed-optimized and memory-efficient training implementations.
 """
 
-from typing import Tuple
-
 import jax
-from jax import tree, numpy as jnp
-from flax import nnx
+from jax import numpy as jnp
 from jaxtyping import Array
 
 from ..tfmpe import TFMPE
 from ...preprocessing.tokens import Tokens
 
 import dataclasses
+
+from .bottom_up import fit_bottom_up
+from .directly import fit_directly
+from .posterior_factorisation import fit_pf
 
 def _cfm_loss(
     tfmpe: TFMPE,
@@ -78,10 +79,6 @@ def _cfm_loss(
         jnp.square(v_pred - u_target)
     )
 
-
-from .bottom_up import fit_bottom_up
-from .directly import fit_directly
-from .posterior_factorisation import fit_pf
 
 __all__ = [
     "_cfm_loss",

--- a/tfmpe/estimators/training/__init__.py
+++ b/tfmpe/estimators/training/__init__.py
@@ -15,73 +15,10 @@ import dataclasses
 from .bottom_up import fit_bottom_up
 from .directly import fit_directly
 from .posterior_factorisation import fit_pf
-
-def _cfm_loss(
-    tfmpe: TFMPE,
-    tokens: Tokens,
-    rng: Array,
-) -> Array:
-    """Continuous Flow Matching loss with batched inputs.
-
-    Computes CFM loss for batched inputs with leading batch
-    dimension. Returns scalar loss averaged over batch.
-
-    Parameters
-    ----------
-    tfmpe : TFMPE
-        TFMPE model instance
-    tokens: Tokens
-        Tokens to compute loss over
-    time : Array
-        Time points for batch. Shape: (batch,)
-
-    Returns
-    -------
-    Array
-        Scalar loss (averaged over batch)
-    """
-    sigma_min = 0.001
-    theta_data = tokens.data[:, tokens.partition_idx:]
-
-    # Sample from base distribution
-    theta_0 = tfmpe.base_dist.sample(theta_data.shape)
-
-    # Reshape time for broadcasting: (batch,) -> (batch, 1, 1)
-    # theta_data shape: (batch, n_tokens, token_dim)
-    time = jax.random.uniform(rng, (tokens.data.shape[0],))
-    time_bc = time[:, None, None]
-
-    # Compute flow path interpolation
-    sigma_t = 1.0 - (1.0 - sigma_min) * time_bc
-    theta_t = theta_0 * sigma_t + theta_data * time_bc
-
-    # Compute target velocity
-    # u_t = (theta - (1 - sigma_min) * theta_t) / (1 - sigma_t)
-    numerator = theta_data - (1.0 - sigma_min) * theta_t
-    denominator = 1.0 - (1.0 - sigma_min) * time_bc
-    u_target = numerator / denominator
-
-    # Set theta.data to interpolated values and evaluate vf
-    new_data = tokens.data.at[:, tokens.partition_idx:].set(theta_t)
-    theta_t_tokens = dataclasses.replace(tokens, data = new_data)
-    v_pred = tfmpe.vf_network(
-        theta_t_tokens,
-        time
-    )
-
-    if tokens.padding_mask is not None:
-        theta_padding_mask = tokens.padding_mask[:,tokens.partition_idx:,None]
-        return jnp.sum(
-            jnp.square(v_pred - u_target) * theta_padding_mask
-        ) / jnp.sum(theta_padding_mask)
-
-    return jnp.mean(
-        jnp.square(v_pred - u_target)
-    )
-
+from .loss import cfm_loss
 
 __all__ = [
-    "_cfm_loss",
+    "cfm_loss",
     "fit_bottom_up",
     "fit_directly",
     "fit_pf",

--- a/tfmpe/estimators/training/__init__.py
+++ b/tfmpe/estimators/training/__init__.py
@@ -1,0 +1,91 @@
+"""Training loops for TFMPE models.
+
+Provides speed-optimized and memory-efficient training implementations.
+"""
+
+from typing import Tuple
+
+import jax
+from jax import tree, numpy as jnp
+from flax import nnx
+from jaxtyping import Array
+
+from ..tfmpe import TFMPE
+from ...preprocessing.tokens import Tokens
+
+import dataclasses
+
+def _cfm_loss(
+    tfmpe: TFMPE,
+    tokens: Tokens,
+    rng: Array,
+) -> Array:
+    """Continuous Flow Matching loss with batched inputs.
+
+    Computes CFM loss for batched inputs with leading batch
+    dimension. Returns scalar loss averaged over batch.
+
+    Parameters
+    ----------
+    tfmpe : TFMPE
+        TFMPE model instance
+    tokens: Tokens
+        Tokens to compute loss over
+    time : Array
+        Time points for batch. Shape: (batch,)
+
+    Returns
+    -------
+    Array
+        Scalar loss (averaged over batch)
+    """
+    sigma_min = 0.001
+    theta_data = tokens.data[:, tokens.partition_idx:]
+
+    # Sample from base distribution
+    theta_0 = tfmpe.base_dist.sample(theta_data.shape)
+
+    # Reshape time for broadcasting: (batch,) -> (batch, 1, 1)
+    # theta_data shape: (batch, n_tokens, token_dim)
+    time = jax.random.uniform(rng, (tokens.data.shape[0],))
+    time_bc = time[:, None, None]
+
+    # Compute flow path interpolation
+    sigma_t = 1.0 - (1.0 - sigma_min) * time_bc
+    theta_t = theta_0 * sigma_t + theta_data * time_bc
+
+    # Compute target velocity
+    # u_t = (theta - (1 - sigma_min) * theta_t) / (1 - sigma_t)
+    numerator = theta_data - (1.0 - sigma_min) * theta_t
+    denominator = 1.0 - (1.0 - sigma_min) * time_bc
+    u_target = numerator / denominator
+
+    # Set theta.data to interpolated values and evaluate vf
+    new_data = tokens.data.at[:, tokens.partition_idx:].set(theta_t)
+    theta_t_tokens = dataclasses.replace(tokens, data = new_data)
+    v_pred = tfmpe.vf_network(
+        theta_t_tokens,
+        time
+    )
+
+    if tokens.padding_mask is not None:
+        theta_padding_mask = tokens.padding_mask[:,tokens.partition_idx:,None]
+        return jnp.sum(
+            jnp.square(v_pred - u_target) * theta_padding_mask
+        ) / jnp.sum(theta_padding_mask)
+
+    return jnp.mean(
+        jnp.square(v_pred - u_target)
+    )
+
+
+from .bottom_up import fit_bottom_up
+from .directly import fit_directly
+from .posterior_factorisation import fit_pf
+
+__all__ = [
+    "_cfm_loss",
+    "fit_bottom_up",
+    "fit_directly",
+    "fit_pf",
+]

--- a/tfmpe/estimators/training/bottom_up.py
+++ b/tfmpe/estimators/training/bottom_up.py
@@ -332,7 +332,7 @@ def fit_bottom_up(
 
         y_n = tfmpe_local.sample_posterior_batched(
             tokens,
-            batch_size=10_000
+            batch_size=100
         )
 
         # Create training tokens for second fit

--- a/tfmpe/estimators/training/bottom_up.py
+++ b/tfmpe/estimators/training/bottom_up.py
@@ -15,7 +15,7 @@ from ...preprocessing.combine import combine_tokens
 from ...preprocessing.utils import Labeller
 from ...nn.training import fit_memory_efficient
 
-from . import _cfm_loss
+from .loss import cfm_loss as _cfm_loss
 
 
 def fit_bottom_up(

--- a/tfmpe/estimators/training/bottom_up.py
+++ b/tfmpe/estimators/training/bottom_up.py
@@ -1,7 +1,4 @@
-"""Training loops for TFMPE models.
-
-Provides speed-optimized and memory-efficient training implementations.
-"""
+"""Bottom-up multi-round training for TFMPE models."""
 
 from typing import Callable, Dict, List, Tuple, Optional
 from math import prod
@@ -11,77 +8,14 @@ from jax import tree, numpy as jnp
 from flax import nnx
 from jaxtyping import Array, PRNGKeyArray, PyTree
 
-from .tfmpe import TFMPE
-from .proposals import truncated_proposal_sir
-from ..preprocessing.tokens import Tokens
-from ..preprocessing.combine import combine_tokens
-from ..preprocessing.utils import Labeller
-from ..nn.training import fit_memory_efficient
+from ..tfmpe import TFMPE
+from ..proposals import truncated_proposal_sir
+from ...preprocessing.tokens import Tokens
+from ...preprocessing.combine import combine_tokens
+from ...preprocessing.utils import Labeller
+from ...nn.training import fit_memory_efficient
 
-import dataclasses
-
-def _cfm_loss(
-    tfmpe: TFMPE,
-    tokens: Tokens,
-    rng: Array,
-) -> Array:
-    """Continuous Flow Matching loss with batched inputs.
-
-    Computes CFM loss for batched inputs with leading batch
-    dimension. Returns scalar loss averaged over batch.
-
-    Parameters
-    ----------
-    tfmpe : TFMPE
-        TFMPE model instance
-    tokens: Tokens
-        Tokens to compute loss over
-    time : Array
-        Time points for batch. Shape: (batch,)
-
-    Returns
-    -------
-    Array
-        Scalar loss (averaged over batch)
-    """
-    sigma_min = 0.001
-    theta_data = tokens.data[:, tokens.partition_idx:]
-
-    # Sample from base distribution
-    theta_0 = tfmpe.base_dist.sample(theta_data.shape)
-
-    # Reshape time for broadcasting: (batch,) -> (batch, 1, 1)
-    # theta_data shape: (batch, n_tokens, token_dim)
-    time = jax.random.uniform(rng, (tokens.data.shape[0],))
-    time_bc = time[:, None, None]
-
-    # Compute flow path interpolation
-    sigma_t = 1.0 - (1.0 - sigma_min) * time_bc
-    theta_t = theta_0 * sigma_t + theta_data * time_bc
-
-    # Compute target velocity
-    # u_t = (theta - (1 - sigma_min) * theta_t) / (1 - sigma_t)
-    numerator = theta_data - (1.0 - sigma_min) * theta_t
-    denominator = 1.0 - (1.0 - sigma_min) * time_bc
-    u_target = numerator / denominator
-
-    # Set theta.data to interpolated values and evaluate vf
-    new_data = tokens.data.at[:, tokens.partition_idx:].set(theta_t)
-    theta_t_tokens = dataclasses.replace(tokens, data = new_data)
-    v_pred = tfmpe.vf_network(
-        theta_t_tokens,
-        time
-    )
-
-    if tokens.padding_mask is not None:
-        theta_padding_mask = tokens.padding_mask[:,tokens.partition_idx:,None]
-        return jnp.sum(
-            jnp.square(v_pred - u_target) * theta_padding_mask
-        ) / jnp.sum(theta_padding_mask)
-
-    return jnp.mean(
-        jnp.square(v_pred - u_target)
-    )
+from . import _cfm_loss
 
 
 def fit_bottom_up(
@@ -179,7 +113,7 @@ def fit_bottom_up(
     - Not jittable: uses Python loop over rounds
     - Currently only n_rounds=1 is implemented
     - Each round makes TWO fit_memory_efficient() calls
-    - Parameter progression: n=1 local → n=n_groups local
+    - Parameter progression: n=1 local -> n=n_groups local
     - Return value: 4-tuple of losses per round (local & global)
     """
     # Validate inputs
@@ -484,141 +418,3 @@ def fit_bottom_up(
         return tfmpe[1], all_losses
 
     return tfmpe, all_losses
-
-def fit_directly(
-    tfmpe: TFMPE,
-    simulator_fn: Callable,
-    prior_fn: Callable,
-    n_groups: int,
-    n_samples_per_round: int,
-    n_val_samples: int,
-    opt: nnx.Optimizer,
-    n_iter_per_round: int,
-    batch_size: int,
-    rng: PRNGKeyArray,
-    labeller: Labeller,
-    f_in_fn: Optional[Callable] = None,
-    f_in_args: list = [],
-    delta: float = 0.0,
-    patience: int = 0,
-) -> Tuple[TFMPE, Tuple[Array, Array]]:
-    """Version of fit_bottom_up which fits the global estimator directly.
-
-    Parameters
-    ----------
-    tfmpe : TFMPE
-        TFMPE model to train
-    simulator_fn : Callable
-        Function: (rng, params_dict, n, f_in) -> observations_dict
-    prior_fn : Callable
-        Function: (rng, n, n_samples, f_in) -> parameters_dict
-    n_groups : int
-        Number of local groups in full hierarchical model
-    n_samples_per_round : int
-        Number of parameter samples per round
-    n_val_samples : int
-        Number of validation samples
-    opt : nnx.Optimizer
-        NNX optimizer instance (pre-initialized with tfmpe)
-    n_iter_per_round : int
-        Training iterations per round
-    batch_size : int
-        Number of samples per batch for fit_memory_efficient calls
-    rng : PRNGKeyArray
-        PRNG key for sampling
-    independence : Independence
-        Independence structure for token creation
-    labeller : Labeller
-        Labeller instance with label mapping for all parameter and
-        observation keys.
-    f_in_fn : Callable, optional
-        Function to generate functional inputs: (rng, n_samples, *f_in_args) -> f_in_dict
-    f_in_args : list, optional
-        Additional arguments for f_in_fn
-    delta : float, optional
-        Minimum improvement in training loss to reset patience counter.
-        Default is 0.0 (any improvement counts).
-    patience : int, optional
-        Number of epochs to wait for improvement before stopping.
-        Set to 0 to disable early stopping. Default is 0.
-
-    Returns
-    -------
-    Tuple[TFMPE, Tuple[Array, Array]]
-        Trained TFMPE and tuple of (train_losses, val_losses)
-    """
-    rng, key_prior = jax.random.split(rng)
-    rng, key_sim = jax.random.split(rng)
-
-    # Generate functional inputs if provided
-    if f_in_fn is not None:
-        rng, key_f_in = jax.random.split(rng)
-        f_in = f_in_fn(key_f_in, n_samples_per_round, *f_in_args)
-    else:
-        f_in = None
-
-    # Sample theta from prior
-    theta = prior_fn(
-        key_prior,
-        n_groups,
-        n_samples_per_round,
-        f_in
-    )
-
-    # Simulate observations
-    y = simulator_fn(key_sim, theta, n_groups, f_in)
-
-    # Create training tokens combining y and theta with condition
-    train_tokens = Tokens.from_pytree(
-        {**y, **theta},
-        condition=list(y.keys()),
-        labeller=labeller,
-        sample_ndims=1,
-        functional_inputs=f_in
-    )
-
-    # Create validation tokens
-    if f_in_fn is not None:
-        rng, key_val_f_in = jax.random.split(rng)
-        val_f_in = f_in_fn(key_val_f_in, n_val_samples, *f_in_args)
-    else:
-        val_f_in = None
-
-    rng, key_val_prior = jax.random.split(rng)
-    rng, key_val_sim = jax.random.split(rng)
-    val_theta = prior_fn(
-        key_val_prior,
-        n_groups,
-        n_val_samples,
-        val_f_in
-    )
-    val_y = simulator_fn(key_val_sim, val_theta, n_groups, val_f_in)
-
-    val_tokens = Tokens.from_pytree(
-        {**val_y, **val_theta},
-        condition=list(val_y.keys()),
-        labeller=labeller,
-        sample_ndims=1,
-        functional_inputs=val_f_in
-    )
-
-    # Fit p(theta|y) with n=n_groups
-    tfmpe.train()
-    rng, key_fit = jax.random.split(rng)
-    tfmpe, losses = fit_memory_efficient(
-        model=tfmpe,
-        train=train_tokens,
-        val=val_tokens,
-        opt=opt,
-        loss=_cfm_loss,
-        n_iter=n_iter_per_round,
-        batch_size=batch_size,
-        rng=key_fit,
-        delta=delta,
-        patience=patience
-    )
-    train_loss, val_loss = losses
-    print("train_loss", train_loss)
-    print("val_loss", val_loss)
-
-    return tfmpe, (train_loss, val_loss)

--- a/tfmpe/estimators/training/bottom_up.py
+++ b/tfmpe/estimators/training/bottom_up.py
@@ -256,8 +256,8 @@ def fit_bottom_up(
             delta=1e-3
         )
         train_loss_local, val_loss_local = first_losses
-        print("train_loss_local", train_loss_local)
-        print("val_loss_local", val_loss_local)
+        print("train_loss_local", train_loss_local.shape)
+        print("val_loss_local", val_loss_local.shape)
 
         # Extract globals and expand to n=n_groups
         if f_in_fn is not None:
@@ -390,7 +390,7 @@ def fit_bottom_up(
         # Second fit_fast (back to training mode)
         tfmpe_global.train()
         rng, key_fit = jax.random.split(rng)
-        print('fit_memory_efficient')
+        print('fit_memory_efficient for global posterior')
         tfmpe_global, second_losses = fit_memory_efficient(
             model=tfmpe_global,
             train=global_train_tokens,

--- a/tfmpe/estimators/training/bottom_up.py
+++ b/tfmpe/estimators/training/bottom_up.py
@@ -40,7 +40,8 @@ def fit_bottom_up(
     f_in_fn: Optional[Callable]=None,
     f_in_args: list=[],
     f_in_args_global: list=[],
-    epsilon: float = 1e-3
+    epsilon: float = 1e-3,
+    sample_batch_size: int = 1000
 ) -> Tuple[TFMPE, List[Tuple[Array, Array, Array, Array]]]:
     """Multi-round bottom-up training algorithm.
 
@@ -332,7 +333,7 @@ def fit_bottom_up(
 
         y_n = tfmpe_local.sample_posterior_batched(
             tokens,
-            batch_size=100
+            batch_size=sample_batch_size
         )
 
         # Create training tokens for second fit

--- a/tfmpe/estimators/training/directly.py
+++ b/tfmpe/estimators/training/directly.py
@@ -11,7 +11,7 @@ from ...preprocessing.tokens import Tokens
 from ...preprocessing.utils import Labeller
 from ...nn.training import fit_memory_efficient
 
-from . import _cfm_loss
+from .loss import cfm_loss as _cfm_loss
 
 
 def fit_directly(

--- a/tfmpe/estimators/training/directly.py
+++ b/tfmpe/estimators/training/directly.py
@@ -1,6 +1,6 @@
 """Direct training for TFMPE models."""
 
-from typing import Callable, List, Tuple, Optional
+from typing import Callable, Tuple, Optional
 
 import jax
 from flax import nnx

--- a/tfmpe/estimators/training/directly.py
+++ b/tfmpe/estimators/training/directly.py
@@ -1,0 +1,151 @@
+"""Direct training for TFMPE models."""
+
+from typing import Callable, List, Tuple, Optional
+
+import jax
+from flax import nnx
+from jaxtyping import Array, PRNGKeyArray
+
+from ..tfmpe import TFMPE
+from ...preprocessing.tokens import Tokens
+from ...preprocessing.utils import Labeller
+from ...nn.training import fit_memory_efficient
+
+from . import _cfm_loss
+
+
+def fit_directly(
+    tfmpe: TFMPE,
+    simulator_fn: Callable,
+    prior_fn: Callable,
+    n_groups: int,
+    n_samples_per_round: int,
+    n_val_samples: int,
+    opt: nnx.Optimizer,
+    n_iter_per_round: int,
+    batch_size: int,
+    rng: PRNGKeyArray,
+    labeller: Labeller,
+    f_in_fn: Optional[Callable] = None,
+    f_in_args: list = [],
+    delta: float = 0.0,
+    patience: int = 0,
+) -> Tuple[TFMPE, Tuple[Array, Array]]:
+    """Version of fit_bottom_up which fits the global estimator directly.
+
+    Parameters
+    ----------
+    tfmpe : TFMPE
+        TFMPE model to train
+    simulator_fn : Callable
+        Function: (rng, params_dict, n, f_in) -> observations_dict
+    prior_fn : Callable
+        Function: (rng, n, n_samples, f_in) -> parameters_dict
+    n_groups : int
+        Number of local groups in full hierarchical model
+    n_samples_per_round : int
+        Number of parameter samples per round
+    n_val_samples : int
+        Number of validation samples
+    opt : nnx.Optimizer
+        NNX optimizer instance (pre-initialized with tfmpe)
+    n_iter_per_round : int
+        Training iterations per round
+    batch_size : int
+        Number of samples per batch for fit_memory_efficient calls
+    rng : PRNGKeyArray
+        PRNG key for sampling
+    labeller : Labeller
+        Labeller instance with label mapping for all parameter and
+        observation keys.
+    f_in_fn : Callable, optional
+        Function to generate functional inputs: (rng, n_samples, *f_in_args) -> f_in_dict
+    f_in_args : list, optional
+        Additional arguments for f_in_fn
+    delta : float, optional
+        Minimum improvement in training loss to reset patience counter.
+        Default is 0.0 (any improvement counts).
+    patience : int, optional
+        Number of epochs to wait for improvement before stopping.
+        Set to 0 to disable early stopping. Default is 0.
+
+    Returns
+    -------
+    Tuple[TFMPE, Tuple[Array, Array]]
+        Trained TFMPE and tuple of (train_losses, val_losses)
+    """
+    rng, key_prior = jax.random.split(rng)
+    rng, key_sim = jax.random.split(rng)
+
+    # Generate functional inputs if provided
+    if f_in_fn is not None:
+        rng, key_f_in = jax.random.split(rng)
+        f_in = f_in_fn(key_f_in, n_samples_per_round, *f_in_args)
+    else:
+        f_in = None
+
+    # Sample theta from prior
+    theta = prior_fn(
+        key_prior,
+        n_groups,
+        n_samples_per_round,
+        f_in
+    )
+
+    # Simulate observations
+    y = simulator_fn(key_sim, theta, n_groups, f_in)
+
+    # Create training tokens combining y and theta with condition
+    train_tokens = Tokens.from_pytree(
+        {**y, **theta},
+        condition=list(y.keys()),
+        labeller=labeller,
+        sample_ndims=1,
+        functional_inputs=f_in
+    )
+
+    # Create validation tokens
+    if f_in_fn is not None:
+        rng, key_val_f_in = jax.random.split(rng)
+        val_f_in = f_in_fn(key_val_f_in, n_val_samples, *f_in_args)
+    else:
+        val_f_in = None
+
+    rng, key_val_prior = jax.random.split(rng)
+    rng, key_val_sim = jax.random.split(rng)
+    val_theta = prior_fn(
+        key_val_prior,
+        n_groups,
+        n_val_samples,
+        val_f_in
+    )
+    val_y = simulator_fn(key_val_sim, val_theta, n_groups, val_f_in)
+
+    val_tokens = Tokens.from_pytree(
+        {**val_y, **val_theta},
+        condition=list(val_y.keys()),
+        labeller=labeller,
+        sample_ndims=1,
+        functional_inputs=val_f_in
+    )
+
+    # Fit p(theta|y) with n=n_groups
+    tfmpe.train()
+    rng, key_fit = jax.random.split(rng)
+    tfmpe, losses = fit_memory_efficient(
+        model=tfmpe,
+        train=train_tokens,
+        val=val_tokens,
+        opt=opt,
+        loss=_cfm_loss,
+        n_iter=n_iter_per_round,
+        batch_size=batch_size,
+        rng=key_fit,
+        delta=delta,
+        patience=patience
+    )
+    train_loss, val_loss = losses
+    print("train_loss", train_loss)
+    print("val_loss", val_loss)
+
+    return tfmpe, (train_loss, val_loss)

--- a/tfmpe/estimators/training/loss.py
+++ b/tfmpe/estimators/training/loss.py
@@ -1,0 +1,76 @@
+"""Training loops for TFMPE models.
+
+Provides speed-optimized and memory-efficient training implementations.
+"""
+
+import jax
+from jax import numpy as jnp
+from jaxtyping import Array
+
+from ..tfmpe import TFMPE
+from ...preprocessing.tokens import Tokens
+
+import dataclasses
+
+def cfm_loss(
+    tfmpe: TFMPE,
+    tokens: Tokens,
+    rng: Array,
+) -> Array:
+    """Continuous Flow Matching loss with batched inputs.
+
+    Computes CFM loss for batched inputs with leading batch
+    dimension. Returns scalar loss averaged over batch.
+
+    Parameters
+    ----------
+    tfmpe : TFMPE
+        TFMPE model instance
+    tokens: Tokens
+        Tokens to compute loss over
+    time : Array
+        Time points for batch. Shape: (batch,)
+
+    Returns
+    -------
+    Array
+        Scalar loss (averaged over batch)
+    """
+    sigma_min = 0.001
+    theta_data = tokens.data[:, tokens.partition_idx:]
+
+    # Sample from base distribution
+    theta_0 = tfmpe.base_dist.sample(theta_data.shape)
+
+    # Reshape time for broadcasting: (batch,) -> (batch, 1, 1)
+    # theta_data shape: (batch, n_tokens, token_dim)
+    time = jax.random.uniform(rng, (tokens.data.shape[0],))
+    time_bc = time[:, None, None]
+
+    # Compute flow path interpolation
+    sigma_t = 1.0 - (1.0 - sigma_min) * time_bc
+    theta_t = theta_0 * sigma_t + theta_data * time_bc
+
+    # Compute target velocity
+    # u_t = (theta - (1 - sigma_min) * theta_t) / (1 - sigma_t)
+    numerator = theta_data - (1.0 - sigma_min) * theta_t
+    denominator = 1.0 - (1.0 - sigma_min) * time_bc
+    u_target = numerator / denominator
+
+    # Set theta.data to interpolated values and evaluate vf
+    new_data = tokens.data.at[:, tokens.partition_idx:].set(theta_t)
+    theta_t_tokens = dataclasses.replace(tokens, data = new_data)
+    v_pred = tfmpe.vf_network(
+        theta_t_tokens,
+        time
+    )
+
+    if tokens.padding_mask is not None:
+        theta_padding_mask = tokens.padding_mask[:,tokens.partition_idx:,None]
+        return jnp.sum(
+            jnp.square(v_pred - u_target) * theta_padding_mask
+        ) / jnp.sum(theta_padding_mask)
+
+    return jnp.mean(
+        jnp.square(v_pred - u_target)
+    )

--- a/tfmpe/estimators/training/posterior_factorisation.py
+++ b/tfmpe/estimators/training/posterior_factorisation.py
@@ -47,6 +47,7 @@ def fit_pf(
     f_in_args: list = [],
     delta: float = 0.0,
     patience: int = 0,
+    sample_batch_size: int = 1000
 ) -> Tuple[TFMPE, TFMPE, Tuple[Tuple[Array, Array], Tuple[Array, Array]]]:
     """Posterior factorised training with separate global and local estimators.
 
@@ -106,17 +107,13 @@ def fit_pf(
     # sum(samples_per_n * n for n in 1..n_groups) ≈ n_samples
     budget_unit = n_groups * (n_groups + 1) // 2
     samples_per_n = n_samples // budget_unit
-    val_samples_per_n = n_val_samples // budget_unit
+    val_samples_per_n = max(1, n_val_samples // budget_unit)
 
     total_train_samples = samples_per_n * n_groups
     assert total_train_samples >= batch_size, (
         f"n_samples={n_samples} too small for n_groups={n_groups}: "
         f"total_train_samples={total_train_samples} < batch_size={batch_size}. "
         f"Need n_samples >= {batch_size * budget_unit // n_groups}."
-    )
-    assert val_samples_per_n >= 1, (
-        f"n_val_samples={n_val_samples} too small for n_groups={n_groups}: "
-        f"Need n_val_samples >= {budget_unit}."
     )
 
     # ----------------------------------------------------------------
@@ -212,7 +209,7 @@ def fit_pf(
 
         # Sample global posterior
         sampled = tfmpe_global.sample_posterior_batched(
-            tokens_for_sampling, batch_size=10_000
+            tokens_for_sampling, batch_size=sample_batch_size
         )
 
         # Decode sampled tokens back to dict

--- a/tfmpe/estimators/training/posterior_factorisation.py
+++ b/tfmpe/estimators/training/posterior_factorisation.py
@@ -24,7 +24,7 @@ from ...preprocessing.combine import combine_tokens
 from ...preprocessing.utils import Labeller
 from ...nn.training import fit_memory_efficient
 
-from . import _cfm_loss
+from .loss import cfm_loss as _cfm_loss
 
 
 def fit_pf(

--- a/tfmpe/estimators/training/posterior_factorisation.py
+++ b/tfmpe/estimators/training/posterior_factorisation.py
@@ -108,10 +108,11 @@ def fit_pf(
     samples_per_n = n_samples // budget_unit
     val_samples_per_n = n_val_samples // budget_unit
 
-    assert samples_per_n >= batch_size, (
+    total_train_samples = samples_per_n * n_groups
+    assert total_train_samples >= batch_size, (
         f"n_samples={n_samples} too small for n_groups={n_groups}: "
-        f"samples_per_n={samples_per_n} < batch_size={batch_size}. "
-        f"Need n_samples >= {batch_size * budget_unit}."
+        f"total_train_samples={total_train_samples} < batch_size={batch_size}. "
+        f"Need n_samples >= {batch_size * budget_unit // n_groups}."
     )
     assert val_samples_per_n >= 1, (
         f"n_val_samples={n_val_samples} too small for n_groups={n_groups}: "

--- a/tfmpe/estimators/training/posterior_factorisation.py
+++ b/tfmpe/estimators/training/posterior_factorisation.py
@@ -27,6 +27,26 @@ from ...nn.training import fit_memory_efficient
 from .loss import cfm_loss as _cfm_loss
 
 
+def _sample_sizes_stick_breaking(
+    rng: PRNGKeyArray, budget: int, n_groups: int
+) -> Tuple[dict, PRNGKeyArray]:
+    """Sample a bag of group sizes via stick-breaking (scheme S1).
+
+    Sequentially draws n ~ Uniform{1, ..., min(n_groups, remaining)} until the
+    simulation budget is exhausted. Uses the budget exactly. Returns a dict
+    mapping group size -> number of rows at that size, plus the advanced rng.
+    """
+    counts: dict = {}
+    remaining = int(budget)
+    while remaining > 0:
+        max_n = min(n_groups, remaining)
+        rng, key = jax.random.split(rng)
+        n = int(jax.random.randint(key, (), 1, max_n + 1))
+        counts[n] = counts.get(n, 0) + 1
+        remaining -= n
+    return counts, rng
+
+
 def fit_pf(
     tfmpe_global: TFMPE,
     tfmpe_local: TFMPE,
@@ -103,17 +123,17 @@ def fit_pf(
          ((global_train_loss, global_val_loss),
           (local_train_loss, local_val_loss)))
     """
-    # Budget: a sample at group count n costs n simulations.
-    # sum(samples_per_n * n for n in 1..n_groups) ≈ n_samples
-    budget_unit = n_groups * (n_groups + 1) // 2
-    samples_per_n = n_samples // budget_unit
-    val_samples_per_n = max(1, n_val_samples // budget_unit)
+    # Budget: a sample at group count n costs n simulations. Sizes are drawn
+    # via stick-breaking (scheme S1): n ~ Uniform{1, ..., min(n_groups,
+    # remaining)} until the budget is exhausted. This uses the full budget
+    # exactly and does not require a minimum of one sample per size.
+    train_counts, rng = _sample_sizes_stick_breaking(rng, n_samples, n_groups)
+    val_counts, rng = _sample_sizes_stick_breaking(rng, n_val_samples, n_groups)
 
-    total_train_samples = samples_per_n * n_groups
+    total_train_samples = sum(train_counts.values())
     assert total_train_samples >= batch_size, (
         f"n_samples={n_samples} too small for n_groups={n_groups}: "
-        f"total_train_samples={total_train_samples} < batch_size={batch_size}. "
-        f"Need n_samples >= {batch_size * budget_unit // n_groups}."
+        f"total_train_samples={total_train_samples} < batch_size={batch_size}."
     )
 
     # ----------------------------------------------------------------
@@ -122,12 +142,12 @@ def fit_pf(
     data_per_n = {}  # n -> (theta_g, theta_l, y, f_in)
     global_train_tokens = None
 
-    for n in range(1, n_groups + 1):
+    for n, count in sorted(train_counts.items()):
         rng, key_f_in, key_prior, key_sim = jax.random.split(rng, 4)
 
-        f_in = f_in_fn(key_f_in, samples_per_n, *f_in_args) if f_in_fn else None
+        f_in = f_in_fn(key_f_in, count, *f_in_args) if f_in_fn else None
 
-        theta = prior_fn(key_prior, n, samples_per_n, f_in)
+        theta = prior_fn(key_prior, n, count, f_in)
         y = simulator_fn(key_sim, theta, n, f_in)
 
         theta_g = {k: v for k, v in theta.items() if k in global_names}
@@ -150,12 +170,12 @@ def fit_pf(
     # Generate global validation tokens (varying n_groups)
     global_val_tokens = None
 
-    for n in range(1, n_groups + 1):
+    for n, count in sorted(val_counts.items()):
         rng, key_f_in, key_prior, key_sim = jax.random.split(rng, 4)
 
-        val_f_in = f_in_fn(key_f_in, val_samples_per_n, *f_in_args) if f_in_fn else None
+        val_f_in = f_in_fn(key_f_in, count, *f_in_args) if f_in_fn else None
 
-        val_theta = prior_fn(key_prior, n, val_samples_per_n, val_f_in)
+        val_theta = prior_fn(key_prior, n, count, val_f_in)
         val_y = simulator_fn(key_sim, val_theta, n, val_f_in)
 
         val_theta_g = {k: v for k, v in val_theta.items() if k in global_names}
@@ -195,7 +215,7 @@ def fit_pf(
     # ----------------------------------------------------------------
     local_train_tokens = None
 
-    for n in range(1, n_groups + 1):
+    for n in sorted(data_per_n):
         theta_g, theta_l, y, f_in = data_per_n[n]
 
         # Create sampling tokens from {y, theta_g} with condition=y keys

--- a/tfmpe/estimators/training/posterior_factorisation.py
+++ b/tfmpe/estimators/training/posterior_factorisation.py
@@ -1,0 +1,302 @@
+"""Posterior factorised training for TFMPE models.
+
+Decomposes the hierarchical posterior as:
+    p(theta_g, theta_l | y) = p(theta_g | y) * prod_s p(theta_l[s] | theta_g, y_[s])
+
+Training proceeds sequentially:
+1. Train global estimator q(theta_g | y) on prior predictive data with
+   varying n_groups (1 to n), padded to max.
+2. Sample the trained global estimator to get theta_g* given simulated y.
+3. Train local estimator q(theta_l[s] | theta_g, y_[s]) reusing the same y
+   (reshaped to single-group), with theta_g* as conditioning.
+"""
+
+from typing import Callable, List, Tuple, Optional
+
+import jax
+from jax import tree, numpy as jnp
+from flax import nnx
+from jaxtyping import Array, PRNGKeyArray
+
+from ..tfmpe import TFMPE
+from ...preprocessing.tokens import Tokens
+from ...preprocessing.combine import combine_tokens
+from ...preprocessing.utils import Labeller
+from ...nn.training import fit_memory_efficient
+
+from . import _cfm_loss
+
+
+def fit_pf(
+    tfmpe_global: TFMPE,
+    tfmpe_local: TFMPE,
+    simulator_fn: Callable,
+    prior_fn: Callable,
+    local_fn: Callable,
+    global_names: List[str],
+    n_groups: int,
+    n_samples: int,
+    n_val_samples: int,
+    opt_global: nnx.Optimizer,
+    opt_local: nnx.Optimizer,
+    n_iter: int,
+    batch_size: int,
+    rng: PRNGKeyArray,
+    labeller: Labeller,
+    f_in_fn: Optional[Callable] = None,
+    f_in_args: list = [],
+    delta: float = 0.0,
+    patience: int = 0,
+) -> Tuple[TFMPE, TFMPE, Tuple[Tuple[Array, Array], Tuple[Array, Array]]]:
+    """Posterior factorised training with separate global and local estimators.
+
+    Trains two TFMPE instances sequentially:
+    1. Global estimator on prior predictive data with varying group counts
+    2. Local estimator on single-group data conditioned on sampled globals
+
+    Parameters
+    ----------
+    tfmpe_global : TFMPE
+        TFMPE model for global posterior estimation
+    tfmpe_local : TFMPE
+        TFMPE model for local posterior estimation
+    simulator_fn : Callable
+        Function: (rng, params_dict, n, f_in) -> observations_dict
+    prior_fn : Callable
+        Function: (rng, n, n_samples, f_in) -> parameters_dict
+    local_fn : Callable
+        Function: (rng, global_samples, n, f_in) -> local_params_dict
+    global_names : List[str]
+        Names of global parameters
+    n_groups : int
+        Maximum number of groups; training uses uniform [1, n_groups]
+    n_samples : int
+        Total training samples (split evenly across group counts)
+    n_val_samples : int
+        Number of validation samples
+    opt_global : nnx.Optimizer
+        Optimizer for global estimator
+    opt_local : nnx.Optimizer
+        Optimizer for local estimator
+    n_iter : int
+        Training iterations for each estimator
+    batch_size : int
+        Batch size for fit_memory_efficient calls
+    rng : PRNGKeyArray
+        PRNG key
+    labeller : Labeller
+        Labeller instance for token creation
+    f_in_fn : Callable, optional
+        Function to generate functional inputs: (rng, n_samples, *f_in_args) -> f_in_dict
+    f_in_args : list, optional
+        Additional arguments for f_in_fn
+    delta : float, optional
+        Minimum improvement for early stopping. Default 0.0.
+    patience : int, optional
+        Epochs without improvement before stopping. 0 disables. Default 0.
+
+    Returns
+    -------
+    Tuple[TFMPE, TFMPE, Tuple[Tuple[Array, Array], Tuple[Array, Array]]]
+        (trained_global, trained_local,
+         ((global_train_loss, global_val_loss),
+          (local_train_loss, local_val_loss)))
+    """
+    # Budget: a sample at group count n costs n simulations.
+    # sum(samples_per_n * n for n in 1..n_groups) ≈ n_samples
+    budget_unit = n_groups * (n_groups + 1) // 2
+    samples_per_n = n_samples // budget_unit
+    val_samples_per_n = n_val_samples // budget_unit
+
+    assert samples_per_n >= batch_size, (
+        f"n_samples={n_samples} too small for n_groups={n_groups}: "
+        f"samples_per_n={samples_per_n} < batch_size={batch_size}. "
+        f"Need n_samples >= {batch_size * budget_unit}."
+    )
+    assert val_samples_per_n >= 1, (
+        f"n_val_samples={n_val_samples} too small for n_groups={n_groups}: "
+        f"Need n_val_samples >= {budget_unit}."
+    )
+
+    # ----------------------------------------------------------------
+    # Phase A: Generate simulation data with varying n_groups
+    # ----------------------------------------------------------------
+    data_per_n = {}  # n -> (theta_g, theta_l, y, f_in)
+    global_train_tokens = None
+
+    for n in range(1, n_groups + 1):
+        rng, key_f_in, key_prior, key_sim = jax.random.split(rng, 4)
+
+        f_in = f_in_fn(key_f_in, samples_per_n, *f_in_args) if f_in_fn else None
+
+        theta = prior_fn(key_prior, n, samples_per_n, f_in)
+        y = simulator_fn(key_sim, theta, n, f_in)
+
+        theta_g = {k: v for k, v in theta.items() if k in global_names}
+        theta_l = {k: v for k, v in theta.items() if k not in global_names}
+        data_per_n[n] = (theta_g, theta_l, y, f_in)
+
+        # Global tokens: condition=y, target=theta_g
+        tokens_n = Tokens.from_pytree(
+            {**y, **theta_g},
+            condition=list(y.keys()),
+            labeller=labeller,
+            sample_ndims=1,
+            functional_inputs=f_in,
+        )
+        global_train_tokens = (
+            tokens_n if global_train_tokens is None
+            else combine_tokens(global_train_tokens, tokens_n)
+        )
+
+    # Generate global validation tokens (varying n_groups)
+    global_val_tokens = None
+
+    for n in range(1, n_groups + 1):
+        rng, key_f_in, key_prior, key_sim = jax.random.split(rng, 4)
+
+        val_f_in = f_in_fn(key_f_in, val_samples_per_n, *f_in_args) if f_in_fn else None
+
+        val_theta = prior_fn(key_prior, n, val_samples_per_n, val_f_in)
+        val_y = simulator_fn(key_sim, val_theta, n, val_f_in)
+
+        val_theta_g = {k: v for k, v in val_theta.items() if k in global_names}
+
+        val_tokens_n = Tokens.from_pytree(
+            {**val_y, **val_theta_g},
+            condition=list(val_y.keys()),
+            labeller=labeller,
+            sample_ndims=1,
+            functional_inputs=val_f_in,
+        )
+        global_val_tokens = (
+            val_tokens_n if global_val_tokens is None
+            else combine_tokens(global_val_tokens, val_tokens_n)
+        )
+
+    # ----------------------------------------------------------------
+    # Phase B: Train global estimator
+    # ----------------------------------------------------------------
+    tfmpe_global.train()
+    rng, key_fit_global = jax.random.split(rng)
+    tfmpe_global, global_losses = fit_memory_efficient(
+        model=tfmpe_global,
+        train=global_train_tokens,
+        val=global_val_tokens,
+        opt=opt_global,
+        loss=_cfm_loss,
+        n_iter=n_iter,
+        batch_size=batch_size,
+        rng=key_fit_global,
+        delta=delta,
+        patience=patience,
+    )
+
+    # ----------------------------------------------------------------
+    # Phase C: Sample global estimator & reshape for local training
+    # ----------------------------------------------------------------
+    local_train_tokens = None
+
+    for n in range(1, n_groups + 1):
+        theta_g, theta_l, y, f_in = data_per_n[n]
+
+        # Create sampling tokens from {y, theta_g} with condition=y keys
+        tokens_for_sampling, decoder = Tokens.from_pytree_with_decoder(
+            {**y, **theta_g},
+            condition=list(y.keys()),
+            labeller=labeller,
+            sample_ndims=1,
+            functional_inputs=f_in,
+        )
+
+        # Sample global posterior
+        sampled = tfmpe_global.sample_posterior_batched(
+            tokens_for_sampling, batch_size=10_000
+        )
+
+        # Decode sampled tokens back to dict
+        decoded = decoder(sampled)
+        theta_g_star = {k: v for k, v in decoded.items() if k in global_names}
+
+        # Reshape to single-group samples
+        # theta_g*: (samples_per_n, ...) -> repeat n times -> (samples_per_n * n, ...)
+        theta_g_expanded = tree.map(
+            lambda v: jnp.repeat(v, n, axis=0), theta_g_star
+        )
+
+        # theta_l: (samples_per_n, n, ...) -> (samples_per_n * n, 1, ...)
+        theta_l_reshaped = tree.map(
+            lambda v: v.reshape((v.shape[0] * n, 1) + v.shape[2:]), theta_l
+        )
+
+        # y: (samples_per_n, n, ...) -> (samples_per_n * n, 1, ...)
+        y_reshaped = tree.map(
+            lambda v: v.reshape((v.shape[0] * n, 1) + v.shape[2:]), y
+        )
+
+        # Handle f_in reshaping
+        local_f_in = None
+        if f_in is not None:
+            f_in_local = {
+                k: v.reshape((v.shape[0] * n, 1) + v.shape[2:])
+                for k, v in f_in.items()
+                if k not in global_names
+            }
+            f_in_global = {
+                k: jnp.repeat(v, n, axis=0)
+                for k, v in f_in.items()
+                if k in global_names
+            }
+            local_f_in = {**f_in_global, **f_in_local}
+
+        # Create local tokens: condition = y + theta_g*, target = theta_l
+        local_tokens_n = Tokens.from_pytree(
+            {**y_reshaped, **theta_g_expanded, **theta_l_reshaped},
+            condition=list(y_reshaped.keys()) + list(theta_g_expanded.keys()),
+            labeller=labeller,
+            sample_ndims=1,
+            functional_inputs=local_f_in,
+        )
+        local_train_tokens = (
+            local_tokens_n if local_train_tokens is None
+            else combine_tokens(local_train_tokens, local_tokens_n)
+        )
+
+    # ----------------------------------------------------------------
+    # Phase D: Train local estimator
+    # ----------------------------------------------------------------
+    # Generate local validation tokens from prior (n=1, true theta_g conditioning)
+    rng, key_f_in, key_prior, key_sim = jax.random.split(rng, 4)
+
+    val_f_in = f_in_fn(key_f_in, n_val_samples, *f_in_args) if f_in_fn else None
+
+    val_theta = prior_fn(key_prior, 1, n_val_samples, val_f_in)
+    val_y = simulator_fn(key_sim, val_theta, 1, val_f_in)
+
+    val_theta_g = {k: v for k, v in val_theta.items() if k in global_names}
+    val_theta_l = {k: v for k, v in val_theta.items() if k not in global_names}
+
+    local_val_tokens = Tokens.from_pytree(
+        {**val_y, **val_theta_g, **val_theta_l},
+        condition=list(val_y.keys()) + list(val_theta_g.keys()),
+        labeller=labeller,
+        sample_ndims=1,
+        functional_inputs=val_f_in,
+    )
+
+    tfmpe_local.train()
+    rng, key_fit_local = jax.random.split(rng)
+    tfmpe_local, local_losses = fit_memory_efficient(
+        model=tfmpe_local,
+        train=local_train_tokens,
+        val=local_val_tokens,
+        opt=opt_local,
+        loss=_cfm_loss,
+        n_iter=n_iter,
+        batch_size=batch_size,
+        rng=key_fit_local,
+        delta=delta,
+        patience=patience,
+    )
+
+    return tfmpe_global, tfmpe_local, (global_losses, local_losses)

--- a/tfmpe/metrics/lc2st.py
+++ b/tfmpe/metrics/lc2st.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 
 def _fit_classifier(
     seed: jnp.ndarray,
-    classifier: Classifier, 
+    classifier: Classifier,
     u: jnp.ndarray,
     labels: jnp.ndarray,
     num_epochs=100,
@@ -31,7 +31,7 @@ def _fit_classifier(
 
     data = {"data": {"u": u[:n_split], "y": labels[:n_split]}}
     val = {"data": {"u": u[n_split:], "y": labels[n_split:]}}
-    
+
     opt = nnx.Optimizer(classifier, optimizer, wrt=nnx.Param)
 
     return fit_memory_efficient(
@@ -49,7 +49,7 @@ def _fit_classifier(
 
 def _train_lc2st_classifiers(
     rng_key: Array,
-    d_cal: Tuple[Array, Array, Array], 
+    d_cal: Tuple[Array, Array, Array],
     classifier: MultiFoldBinaryMLPClassifier,
     null_classifier: MultiBinaryMLPClassifier,
     num_epochs: int,
@@ -57,12 +57,12 @@ def _train_lc2st_classifiers(
 ) -> None:
     """
     Local-Classifier 2 Sample Test – training both main and null classifiers.
-    
+
     Input:
         rng_key: JAX PRNG key for reproducibility.
         d_cal: Calibration data tuple (x, theta, theta_q) where:
             - x: observations from p(x|theta)
-            - theta: parameters from joint distribution p(theta, x)  
+            - theta: parameters from joint distribution p(theta, x)
             - theta_q: parameters from estimated posterior q(theta|x)
         classifier: Main binary classifier for (x, theta) concatenated input
         null_classifier: Multiple null classifiers for permuted label training
@@ -88,7 +88,7 @@ def _train_lc2st_classifiers(
     n_ensemble = classifier.n
     n_folds = classifier.n_fold
     dim = u_main.shape[-1]
-    
+
     # Implement folds
     shift = N_cal // n_folds
     if n_folds > 1:
@@ -131,24 +131,27 @@ def _train_lc2st_classifiers(
 
     # Create 3D input for null classifiers: (batch_size, n_classifiers, feature_dim)
     u_null_base = jnp.concatenate([u_joint, u_posterior], axis=0)  # (2*N_cal, feature_dim)
+    print("Printing shapes for debugging:")
+    print(f"u_null_base shape: {u_null_base.shape}")
+    print(f"n_null: {n_null}")
+    print("2*N_cal:", 2*N_cal)
     u_null = jnp.broadcast_to(
-        u_null_base[None, :, :], 
-        (n_null, 2*N_cal, u_null_base.shape[-1])
-    ).transpose(1, 0, 2)  # (2*N_cal, n_classifiers, feature_dim)
+        u_null_base[:, None, :],
+        (2*N_cal, n_null, u_null_base.shape[-1])) # (2*N_cal, n_classifiers, feature_dim)
 
     # Generate different permuted labels for each null classifier
     base_labels = jnp.concatenate([jnp.zeros(N_cal), jnp.ones(N_cal)], axis=0)
     null_keys = jr.split(null_key, n_null)
-    
+
     def permute_labels(key):
         return jr.permutation(key, base_labels)
-    
+
     # Create permuted labels for each classifier
     permuted_labels = jnp.stack([
         permute_labels(key)
         for key in null_keys
     ], axis=1)  # (2*N_cal, n_classifiers)
-    
+
     _fit_classifier(
         null_key,
         null_classifier,
@@ -162,19 +165,19 @@ def _train_lc2st_classifiers(
 
 def _evaluate_lc2st(
     observation: Array,
-    posterior_samples: Array, 
+    posterior_samples: Array,
     main_classifier: MultiFoldBinaryMLPClassifier,
     null_classifier: MultiBinaryMLPClassifier,
 ) -> Tuple[Array, Array]:
     """
     Local-Classifier 2 Sample Test evaluation in posterior space.
-    
+
     Input:
         observation: The specific observation to evaluate consistency at.
         posterior_samples: Samples from estimated posterior q(theta|observation).
         main_classifier: Main classifier trained to distinguish joint vs posterior.
         null_classifier: Null classifiers trained with permuted labels.
-    
+
     Output:
         null_test_statistics: Test statistics for each null classifier.
         t_mse_val: The calculated MSE test statistic for posterior samples.
@@ -184,10 +187,10 @@ def _evaluate_lc2st(
     null_classifier.eval()
     n_samples = posterior_samples.shape[0]
     n_null = null_classifier.n
-    
+
     # Create inputs for main classifier: (observation, posterior_samples)
     observation_broadcast = jnp.broadcast_to(
-        observation[None, :], 
+        observation[None, :],
         (n_samples, observation.shape[0])
     )
     u_main = jnp.concatenate([observation_broadcast, posterior_samples], axis=-1)
@@ -203,18 +206,18 @@ def _evaluate_lc2st(
     # t̂MSE = (1/n_samples) * sum((d_main(observation, theta_i) - 1/2)^2)
     d_main = main_classifier(u_main_ens)
     t_mse_val = jnp.mean((d_main - 0.5)**2)
-    
+
     # Create 3D inputs for null classifiers
     u_null = jnp.broadcast_to(
         u_main[None, :, :],
         (n_null, n_samples, u_main.shape[-1])
     ).transpose(1, 0, 2)  # (n_samples, n_null, feature_dim)
-    
+
     # Compute null test statistics
     # t̂null_h = (1/n_samples) * sum((d_null_h(observation, theta_i) - 1/2)^2)
     d_null = null_classifier(u_null)  # (n_samples, n_null)
     null_test_statistics = jnp.mean((d_null - 0.5)**2, axis=0)  # (n_null,)
-    
+
     return null_test_statistics, t_mse_val
 
 @dataclass

--- a/tfmpe/metrics/lc2st.py
+++ b/tfmpe/metrics/lc2st.py
@@ -1,0 +1,287 @@
+from functools import partial
+from typing import Tuple
+from jax import random as jr, numpy as jnp, vmap
+from jaxtyping import Array
+from flax import nnx
+import optax
+from ..nn.classifier import (
+    Classifier,
+    MultiBinaryMLPClassifier,
+    MultiFoldBinaryMLPClassifier,
+    ce_loss
+)
+
+from ..nn.training import fit_memory_efficient
+from dataclasses import dataclass
+
+def _fit_classifier(
+    seed: jnp.ndarray,
+    classifier: Classifier, 
+    u: jnp.ndarray,
+    labels: jnp.ndarray,
+    num_epochs=100,
+    batch_size=100,
+    optimizer: optax.GradientTransformation = optax.adam(0.0003),
+    delta=1e-3,
+    patience=100
+    ):
+
+    data = {"data": {"u": u, "y": labels}}
+    
+    opt = nnx.Optimizer(classifier, optimizer, wrt=nnx.Param)
+
+    return fit_memory_efficient(
+        classifier,
+        train=data,
+        val=None,
+        opt=opt,
+        loss=ce_loss,
+        n_iter=num_epochs,
+        batch_size=batch_size,
+        rng=seed,
+        delta=delta,
+        patience=patience
+    )
+
+def _train_lc2st_classifiers(
+    rng_key: Array,
+    d_cal: Tuple[Array, Array, Array], 
+    classifier: MultiFoldBinaryMLPClassifier,
+    null_classifier: MultiBinaryMLPClassifier,
+    num_epochs: int,
+    batch_size: int = 100,
+) -> None:
+    """
+    Local-Classifier 2 Sample Test – training both main and null classifiers.
+    
+    Input:
+        rng_key: JAX PRNG key for reproducibility.
+        d_cal: Calibration data tuple (x, theta, theta_q) where:
+            - x: observations from p(x|theta)
+            - theta: parameters from joint distribution p(theta, x)  
+            - theta_q: parameters from estimated posterior q(theta|x)
+        classifier: Main binary classifier for (x, theta) concatenated input
+        null_classifier: Multiple null classifiers for permuted label training
+        num_epochs: Number of epochs to train both classifiers.
+        batch_size: Batch size for training.
+    """
+    x_cal, theta_cal, theta_q = d_cal
+    N_cal = x_cal.shape[0]
+
+    # Train main classifier
+    # Class C=0: (x, theta) from joint distribution p(theta, x)
+    # Class C=1: (x, theta_q) from posterior q(theta|x) p(x)
+    u_joint = jnp.concatenate([x_cal, theta_cal], axis=-1)
+    u_posterior = jnp.concatenate([x_cal, theta_q], axis=-1)
+    u_main = jnp.concatenate([u_joint, u_posterior], axis=0)
+    labels_main = jnp.concatenate([jnp.zeros(N_cal), jnp.ones(N_cal)], axis=0)
+
+    rng_key, shuffle_key = jr.split(rng_key)
+    shuffled_i = jr.permutation(shuffle_key, N_cal*2)
+    u_main = u_main[shuffled_i]
+    labels_main = labels_main[shuffled_i]
+
+    n_ensemble = classifier.n
+    n_folds = classifier.n_fold
+    dim = u_main.shape[-1]
+    
+    # Implement folds
+    shift = N_cal // n_folds
+    if n_folds > 1:
+        N_cal_main = N_cal - shift
+    else:
+        N_cal_main = N_cal
+
+    @partial(vmap, in_axes=(0, None), out_axes=1)
+    def fold(i, dataset):
+        return jnp.roll(dataset, shift * i, axis=0)[:N_cal_main]
+
+    u_main = fold(jnp.arange(n_folds), u_main)
+    labels_main = fold(jnp.arange(n_folds), labels_main)
+
+    # broadcast to ensembles
+    u_main = jnp.broadcast_to(
+        u_main[:, None, :, :],
+        (N_cal_main, n_ensemble, n_folds, dim)
+    )
+    labels_main = jnp.broadcast_to(
+        labels_main[:, None, :],
+        (N_cal_main, n_ensemble, n_folds)
+    )
+
+    rng_key, main_key = jr.split(rng_key)
+    _fit_classifier(
+        main_key,
+        classifier,
+        u_main,
+        labels_main,
+        num_epochs=num_epochs,
+        batch_size=batch_size,
+        delta=1e-2,
+        patience=100
+    )
+
+    # Train null classifiers with permuted labels
+    n_null = null_classifier.n
+    rng_key, null_key = jr.split(rng_key)
+
+    # Create 3D input for null classifiers: (batch_size, n_classifiers, feature_dim)
+    u_null_base = jnp.concatenate([u_joint, u_posterior], axis=0)  # (2*N_cal, feature_dim)
+    u_null = jnp.broadcast_to(
+        u_null_base[None, :, :], 
+        (n_null, 2*N_cal, u_null_base.shape[-1])
+    ).transpose(1, 0, 2)  # (2*N_cal, n_classifiers, feature_dim)
+
+    # Generate different permuted labels for each null classifier
+    base_labels = jnp.concatenate([jnp.zeros(N_cal), jnp.ones(N_cal)], axis=0)
+    null_keys = jr.split(null_key, n_null)
+    
+    def permute_labels(key):
+        return jr.permutation(key, base_labels)
+    
+    # Create permuted labels for each classifier
+    permuted_labels = jnp.stack([
+        permute_labels(key)
+        for key in null_keys
+    ], axis=1)  # (2*N_cal, n_classifiers)
+    
+    _fit_classifier(
+        null_key,
+        null_classifier,
+        u_null,
+        permuted_labels,
+        num_epochs=num_epochs,
+        batch_size=batch_size,
+        delta=1e-2,
+        patience=100
+    )
+
+def _evaluate_lc2st(
+    observation: Array,
+    posterior_samples: Array, 
+    main_classifier: MultiFoldBinaryMLPClassifier,
+    null_classifier: MultiBinaryMLPClassifier,
+) -> Tuple[Array, Array]:
+    """
+    Local-Classifier 2 Sample Test evaluation in posterior space.
+    
+    Input:
+        observation: The specific observation to evaluate consistency at.
+        posterior_samples: Samples from estimated posterior q(theta|observation).
+        main_classifier: Main classifier trained to distinguish joint vs posterior.
+        null_classifier: Null classifiers trained with permuted labels.
+    
+    Output:
+        null_test_statistics: Test statistics for each null classifier.
+        t_mse_val: The calculated MSE test statistic for posterior samples.
+        p_value: The p-value for the Local-Classifier 2 Sample Test.
+    """
+    main_classifier.eval()
+    null_classifier.eval()
+    n_samples = posterior_samples.shape[0]
+    n_null = null_classifier.n
+    
+    # Create inputs for main classifier: (observation, posterior_samples)
+    observation_broadcast = jnp.broadcast_to(
+        observation[None, :], 
+        (n_samples, observation.shape[0])
+    )
+    u_main = jnp.concatenate([observation_broadcast, posterior_samples], axis=-1)
+    dim = u_main.shape[-1]
+
+    # Broadcast u_main to n_ensembles, n_fold
+    u_main_ens = jnp.broadcast_to(
+        u_main[:, None, None, :],
+        (n_samples, main_classifier.n, main_classifier.n_fold, dim)
+    )
+
+    # Compute main test statistic
+    # t̂MSE = (1/n_samples) * sum((d_main(observation, theta_i) - 1/2)^2)
+    d_main = main_classifier(u_main_ens)
+    t_mse_val = jnp.mean((d_main - 0.5)**2)
+    
+    # Create 3D inputs for null classifiers
+    u_null = jnp.broadcast_to(
+        u_main[None, :, :],
+        (n_null, n_samples, u_main.shape[-1])
+    ).transpose(1, 0, 2)  # (n_samples, n_null, feature_dim)
+    
+    # Compute null test statistics
+    # t̂null_h = (1/n_samples) * sum((d_null_h(observation, theta_i) - 1/2)^2)
+    d_null = null_classifier(u_null)  # (n_samples, n_null)
+    null_test_statistics = jnp.mean((d_null - 0.5)**2, axis=0)  # (n_null,)
+    
+    return null_test_statistics, t_mse_val
+
+@dataclass
+class LC2STResponse:
+    main_stat: Array
+    null_stats: Array
+
+    @property
+    def pvalue(self):
+        x = jnp.mean(self.null_stats >= self.main_stat)
+        x = jnp.maximum(x, 1. / (self.n_null + 1))
+        return x
+
+    @property
+    def n_null(self):
+        return self.null_stats.shape[0]
+
+    def critical_value(self, alpha):
+        return jnp.quantile(self.null_stats, alpha)
+
+
+def run_lc2st(
+    key: Array,
+    d_cal: Tuple[Array, Array, Array],
+    observation: Array,
+    post: Array,
+    latent_dim: int = 32,
+    n_layers: int = 2,
+    num_folds: int = 10,
+    num_ensemble: int = 10,
+    num_null: int = 100,
+    n_epochs: int = 100,
+    ) -> LC2STResponse:
+    rngs = nnx.Rngs(key)
+    dim = d_cal[0].shape[1] + d_cal[1].shape[1]
+    main = MultiFoldBinaryMLPClassifier(
+        dim=dim,
+        latent_dim = latent_dim,
+        n=num_ensemble,
+        n_fold=num_folds,
+        n_layers=n_layers,
+        activation=nnx.relu,
+        rngs=rngs,
+    )
+
+    null_classifier = MultiBinaryMLPClassifier(
+        dim=dim,
+        latent_dim=latent_dim,
+        n_layers=n_layers,
+        activation=nnx.relu,
+        n=num_null,
+        rngs=rngs,
+    )
+
+    # Train both classifiers together
+    train_key, key = jr.split(key)
+    _train_lc2st_classifiers(
+        train_key,
+        d_cal,
+        main,
+        null_classifier,
+        n_epochs
+    )
+
+    null_stats, main_stat = _evaluate_lc2st(
+        observation,
+        post,
+        main,
+        null_classifier,
+    )
+    return LC2STResponse(
+        main_stat = main_stat,
+        null_stats = null_stats,
+    )

--- a/tfmpe/metrics/lc2st.py
+++ b/tfmpe/metrics/lc2st.py
@@ -22,18 +22,22 @@ def _fit_classifier(
     num_epochs=100,
     batch_size=100,
     optimizer: optax.GradientTransformation = optax.adam(0.0003),
-    delta=1e-3,
+    split=.9,
+    delta=1e-2,
     patience=100
     ):
 
-    data = {"data": {"u": u, "y": labels}}
+    n_split = int(u.shape[0] * split)
+
+    data = {"data": {"u": u[:n_split], "y": labels[:n_split]}}
+    val = {"data": {"u": u[n_split:], "y": labels[n_split:]}}
     
     opt = nnx.Optimizer(classifier, optimizer, wrt=nnx.Param)
 
     return fit_memory_efficient(
         classifier,
         train=data,
-        val=None,
+        val=val,
         opt=opt,
         loss=ce_loss,
         n_iter=num_epochs,
@@ -117,7 +121,7 @@ def _train_lc2st_classifiers(
         labels_main,
         num_epochs=num_epochs,
         batch_size=batch_size,
-        delta=1e-2,
+        delta=1e-1,
         patience=100
     )
 
@@ -152,7 +156,7 @@ def _train_lc2st_classifiers(
         permuted_labels,
         num_epochs=num_epochs,
         batch_size=batch_size,
-        delta=1e-2,
+        delta=1e-1,
         patience=100
     )
 

--- a/tfmpe/nn/classifier.py
+++ b/tfmpe/nn/classifier.py
@@ -1,0 +1,147 @@
+from typing import Callable
+from jaxtyping import PyTree, Array
+from flax import nnx
+from jax import numpy as jnp
+
+class FFLayer(nnx.Module):
+
+    activation: Callable
+
+    def __init__(self, dim, activation, dropout_rate=0.5, rngs=nnx.Rngs(0)):
+        self.linear = nnx.Linear(dim, dim, rngs=rngs)
+        self.dropout = nnx.Dropout(dropout_rate, rngs=rngs)
+        self.activation = activation
+
+    def __call__(self, x):
+        x = self.linear(x)
+        x = self.dropout(x)
+        x = self.activation(x)
+        return x
+
+class BinaryMLPClassifier(nnx.Module):
+
+    n_layers: int
+
+    def __init__(
+        self,
+        dim,
+        latent_dim,
+        n_layers,
+        activation,
+        rngs=nnx.Rngs(0)
+        ):
+
+        @nnx.split_rngs(splits=n_layers)
+        @nnx.vmap(in_axes=(0,), out_axes=0)
+        def create_layer(rngs):
+            return FFLayer(latent_dim, activation, rngs=rngs)
+
+        self.layers = create_layer(rngs)
+        self.n_layers = n_layers
+        self.in_layer = nnx.Linear(dim, latent_dim, rngs=rngs)
+        self.output = nnx.Linear(latent_dim, 1, rngs=rngs)
+
+    def __call__(self, u):
+        @nnx.scan(in_axes=(nnx.Carry, 0), out_axes=nnx.Carry)
+        def forward(x, model):
+            x = model(x)
+            return x
+
+        x = self.in_layer(u)
+        x = forward(x, self.layers)
+        x = self.output(x)[..., 0]
+        return nnx.sigmoid(x)
+
+class MultiBinaryMLPClassifier(nnx.Module):
+
+    def __init__(
+        self,
+        dim: int,
+        latent_dim: int,
+        n_layers: int,
+        activation: Callable,
+        n: int,
+        rngs=nnx.Rngs(0)
+        ):
+        """
+        dim: int the latent dimension
+        n_layers: int number of layers
+        activation: Callable activation function
+        n: int number of classifiers to map over
+        rngs: nnx.Rngs
+        """
+        @nnx.split_rngs(splits=n)
+        @nnx.vmap
+        def create_classifier(rngs):
+            return BinaryMLPClassifier(dim, latent_dim, n_layers, activation, rngs=rngs)
+
+        self.classifiers = create_classifier(rngs)
+        self.n = n
+
+    def __call__(self, u):
+        assert u.ndim == 3, f"MultiBinaryMLPClassifier expects 3D input, got {u.ndim}D with shape {u.shape}"
+        assert u.shape[1] == self.n, f"Second dimension must match number of classifiers ({self.n}), got shape {u.shape}"
+        
+        # Input shape is (batch_dim, n_classifiers, z_dim)
+        # We want each classifier to process all batch samples for its corresponding slice
+        @nnx.vmap(in_axes=(0, 1), out_axes=1)
+        def call_classifier_on_slice(cls, u_slice):
+            return cls(u_slice)
+
+        return call_classifier_on_slice(self.classifiers, u)
+
+class MultiFoldBinaryMLPClassifier(nnx.Module):
+
+    def __init__(
+        self,
+        dim: int,
+        latent_dim: int,
+        n_layers: int,
+        activation: Callable,
+        n: int,
+        n_fold: int,
+        rngs=nnx.Rngs(0)
+        ):
+        """
+        dim: int the latent dimension
+        n_layers: int number of layers
+        activation: Callable activation function
+        n: int number of classifiers to map over
+        rngs: nnx.Rngs
+        """
+        @nnx.split_rngs(splits=n)
+        @nnx.vmap
+        def create_classifier(rngs):
+            return BinaryMLPClassifier(dim, latent_dim, n_layers, activation, rngs=rngs)
+
+        self.classifiers = create_classifier(rngs)
+        self.n = n
+        self.n_fold = n_fold
+
+    def __call__(self, u):
+        assert u.ndim == 4, f"MultiFoldBinaryMLPClassifier expects 4D input, got {u.ndim}D with shape {u.shape}"
+        assert u.shape[1] == self.n, f"Second dimension must match number of classifiers ({self.n}), got shape {u.shape}"
+        assert u.shape[2] == self.n_fold, f"Third dimension must match number of folds ({self.n_fold}), got shape {u.shape}"
+        
+        # Input shape is (batch_dim, n_classifiers, z_dim)
+        # We want each classifier to process all batch samples for its corresponding slice
+        @nnx.vmap(in_axes=(0, 1), out_axes=1)
+        @nnx.vmap(in_axes=(None, 1), out_axes=1)
+        def call_classifier_on_slice(cls, u_slice):
+            return cls(u_slice)
+
+        return call_classifier_on_slice(self.classifiers, u)
+
+Classifier = MultiBinaryMLPClassifier | BinaryMLPClassifier | MultiFoldBinaryMLPClassifier
+
+def ce_loss(
+    model: Classifier,
+    batch: PyTree,
+    _: jnp.ndarray
+    ) -> Array:
+    """Calculates binary cross-entropy loss for the classifier."""
+    preds = model(batch['data']['u'])
+    labels = batch['data']['y']
+    preds = jnp.clip(preds, 1e-7, 1 - 1e-7) # Clip to avoid log(0)
+    loss = -jnp.mean(labels * jnp.log(preds) + (1 - labels) * jnp.log(1 - preds))
+    return loss

--- a/tfmpe/nn/mlp.py
+++ b/tfmpe/nn/mlp.py
@@ -1,0 +1,118 @@
+"""MLP model for TFMPE."""
+
+import jax.numpy as jnp
+from jaxtyping import Array
+from flax import nnx
+
+from ..preprocessing.tokens import Tokens
+
+
+class MLP(nnx.Module):
+    """Simple MLP for TFMPE.
+
+    Processes flattened token data through fully connected layers
+    to produce a vector field. Implements the TokenisedVectorField
+    protocol for compatibility with TFMPE.
+
+    Attributes
+    ----------
+    n_target_tokens : int
+        Number of target tokens in output
+    value_dim : int
+        Dimension of token values
+    layers : list
+        List of hidden linear layers
+    output_linear : nnx.Linear
+        Output projection layer
+    """
+
+    def __init__(
+        self,
+        n_ff: int,
+        latent_dim: int,
+        tokens: Tokens,
+        rngs: nnx.Rngs,
+    ) -> None:
+        """Initialize MLP.
+
+        Parameters
+        ----------
+        n_ff : int
+            Number of hidden layers
+        latent_dim : int
+            Width of hidden layers
+        tokens : Tokens
+            Example tokens to deduce input/output dimensions
+        rngs : nnx.Rngs
+            JAX random number generators
+        """
+        n_tokens = tokens.data.shape[-2]
+        value_dim = tokens.data.shape[-1]
+        n_target_tokens = n_tokens - tokens.partition_idx
+
+        self.n_target_tokens = n_target_tokens
+        self.value_dim = value_dim
+
+        # Input: flattened tokens + time
+        input_dim = n_tokens * value_dim + 1
+        output_dim = n_target_tokens * value_dim
+
+        # Build hidden layers
+        layers = []
+        in_dim = input_dim
+        for _ in range(n_ff):
+            layers.append(nnx.Linear(in_dim, latent_dim, rngs=rngs))
+            in_dim = latent_dim
+        self.layers = layers
+
+        self.output_linear = nnx.Linear(latent_dim, output_dim, rngs=rngs)
+
+    def __call__(
+        self,
+        tokens: Tokens,
+        time: Array,
+        deterministic: bool = False,
+    ) -> Array:
+        """Forward pass through MLP.
+
+        Parameters
+        ----------
+        tokens : Tokens
+            Input tokens with data shape (*sample_shape, n_tokens, value_dim)
+        time : Array
+            Time values, scalar or shape (*sample_shape,)
+        deterministic : bool, optional
+            Unused, for API compatibility. Default is False.
+
+        Returns
+        -------
+        Array
+            Output vector field, shape (*sample_shape, n_target_tokens, value_dim)
+        """
+        del deterministic  # Unused
+
+        # tokens.data: (*sample_shape, n_tokens, value_dim)
+        data = tokens.data
+        sample_shape = data.shape[:-2]
+
+        # Flatten last two dims: (*sample_shape, n_tokens * value_dim)
+        x = data.reshape(sample_shape + (-1,))
+
+        # Broadcast time to (*sample_shape, 1)
+        time_expanded = jnp.broadcast_to(
+            jnp.atleast_1d(time)[..., None],
+            sample_shape + (1,)
+        )
+
+        # Concatenate: (*sample_shape, n_tokens * value_dim + 1)
+        x = jnp.concatenate([x, time_expanded], axis=-1)
+
+        # Forward through hidden layers with ReLU
+        for layer in self.layers:
+            x = layer(x)
+            x = nnx.relu(x)
+
+        x = self.output_linear(x)
+
+        # Reshape to (*sample_shape, n_target_tokens, value_dim)
+        return x.reshape(sample_shape + (self.n_target_tokens, self.value_dim))

--- a/tfmpe/nn/mlp.py
+++ b/tfmpe/nn/mlp.py
@@ -63,7 +63,7 @@ class MLP(nnx.Module):
         for _ in range(n_ff):
             layers.append(nnx.Linear(in_dim, latent_dim, rngs=rngs))
             in_dim = latent_dim
-        self.layers = layers
+        self.layers = nnx.List(layers)
 
         self.output_linear = nnx.Linear(latent_dim, output_dim, rngs=rngs)
 

--- a/tfmpe/nn/training.py
+++ b/tfmpe/nn/training.py
@@ -158,7 +158,7 @@ def fit_memory_efficient(
     rng : PRNGKeyArray
         Random number generator key
     delta : float, optional
-        Minimum improvement in training loss to reset patience counter.
+        Minimum improvement in validation loss to reset patience counter.
         Default is 0.0 (any improvement counts).
     patience : int, optional
         Number of epochs to wait for improvement before stopping.
@@ -214,10 +214,10 @@ def fit_memory_efficient(
     val_losses_list: List[Array] = []
 
     # Early stopping state
-    best_train_loss = float('inf')
+    best_val_loss = float('inf')
     epochs_without_improvement = 0
     best_state = None
-    early_stopping_enabled = patience > 0
+    early_stopping_enabled = patience > 0 and val is not None
 
     # Python loop over epochs with progress bar
     pbar = tqdm(range(n_iter), desc="Training")
@@ -267,23 +267,24 @@ def fit_memory_efficient(
 
             # Update progress bar with losses
             pbar.set_postfix(train_loss=f"{float(train_loss):.4f}", val_loss=f"{float(val_loss):.4f}")
-        pbar.set_postfix(train_loss=f"{float(train_loss):.4f}")
 
-        # Early stopping check
-        if early_stopping_enabled:
-            if best_train_loss - float(train_loss) > delta:
-                # Improvement found
-                best_train_loss = float(train_loss)
-                epochs_without_improvement = 0
-                # Save best model state (deep copy since nnx.state returns live view)
-                best_state = tree.map(jnp.copy, nnx.state(model))
-            else:
-                epochs_without_improvement += 1
-                if epochs_without_improvement >= patience:
-                    # Restore best model and stop
-                    assert best_state is not None
-                    nnx.update(model, best_state)
-                    break
+            # Early stopping check
+            if early_stopping_enabled:
+                if best_val_loss - float(val_loss) > delta:
+                    # Improvement found
+                    best_val_loss = float(val_loss)
+                    epochs_without_improvement = 0
+                    # Save best model state (deep copy since nnx.state returns live view)
+                    best_state = tree.map(jnp.copy, nnx.state(model))
+                else:
+                    epochs_without_improvement += 1
+                    if epochs_without_improvement >= patience:
+                        # Restore best model and stop
+                        assert best_state is not None
+                        nnx.update(model, best_state)
+                        break
+        else:
+            pbar.set_postfix(train_loss=f"{float(train_loss):.4f}")
 
     # Stack losses into arrays (may be shorter than n_iter if early stopped)
     train_losses = jnp.stack(train_losses_list)

--- a/tfmpe/nn/training.py
+++ b/tfmpe/nn/training.py
@@ -1,0 +1,295 @@
+from jax import numpy as jnp, random as jr, tree
+from flax import nnx
+from jaxtyping import PyTree, Array
+from typing import Tuple, Callable, List, Optional, Any, TypeVar
+from tqdm import tqdm
+
+M = TypeVar('M', bound=nnx.Module)
+
+def fit_fast(
+    model: M,
+    train: PyTree,
+    val: PyTree,
+    loss: Callable[[Any, PyTree, Array], Array],
+    opt: nnx.Optimizer,
+    n_iter: int,
+    batch_size: int,
+    rng: Array,
+) -> Tuple[M, Tuple[Array, Array]]:
+    """Speed-optimized training loop using JIT compilation.
+
+    Uses nnx.scan for fully jittable training loop with batched
+    loss computation.
+
+    Parameters
+    ----------
+    tfmpe : TFMPE
+        TFMPE model to train
+    train_tokens: Tokens
+        Training tokens
+    val_tokens: Tokens
+        Validation tokens
+    opt : nnx.Optimizer
+        NNX optimizer instance already initialized with tfmpe
+    n_iter : int
+        Number of training iterations
+    batch_size : int
+        Number of samples per batch
+    rng : PRNGKeyArray
+        Random number generator key
+
+    Returns
+    -------
+    Tuple[TFMPE, Tuple[Array, Array]]
+        Trained TFMPE instance and tuple of:
+        - training losses shape (n_iter,)
+        - validation losses shape (n_iter,)
+    """
+    n_train = tree.leaves(train)[0].shape[0]
+    n_batches = n_train // batch_size
+
+    # Batch body: process single batch
+    def batch_body(carry, batch_data):
+        model, opt_model = carry
+        (
+            batch,
+            batch_rng,
+        ) = batch_data
+
+        # Compute loss and gradients
+        def model_loss(model):
+            return loss(
+                model,
+                batch,
+                batch_rng
+            )
+
+        batch_loss, grads = nnx.value_and_grad(model_loss)(model)
+
+        # Update optimizer (updates model in-place)
+        opt_model.update(model, grads)
+
+        return (model, opt_model), batch_loss
+
+    # Epoch body: process all batches in epoch
+    def epoch_body(carry, epoch_rng):
+        model, opt_model = carry
+
+        # Shuffle training data
+        epoch_rng, perm_key = jr.split(epoch_rng)
+        perm = jr.permutation(perm_key, n_train)
+
+        shuffled_tokens = tree.map(
+            lambda x: x[perm[:n_batches * batch_size]].reshape(
+                (n_batches, batch_size) + x.shape[1:]
+            ),
+            train,
+        )
+
+        # Generate RNG keys for each batch
+        epoch_rng, batch_rng = jr.split(epoch_rng)
+        batch_rngs = jr.split(batch_rng, n_batches)
+
+        # Stack batch data along first dimension for scanning
+        batch_data = (
+            shuffled_tokens,
+            batch_rngs,
+        )
+
+        # Scan over batches
+        (model, opt_model), batch_losses = nnx.scan(
+            batch_body
+        )((model, opt_model), batch_data)
+
+        # Average training loss across batches
+        train_loss = jnp.mean(batch_losses)
+
+        # Compute validation loss
+        epoch_rng, key_times = jr.split(epoch_rng)
+
+        val_loss = loss(
+            model,
+            val,
+            key_times
+        )
+
+        return (model, opt_model), (train_loss, val_loss)
+
+    # Scan over epochs
+    epoch_rngs = jr.split(rng, n_iter)
+    (model, _), losses = nnx.scan(epoch_body)(
+        (model, opt), epoch_rngs
+    )
+
+    return model, losses
+
+
+def fit_memory_efficient(
+    model: M,
+    train: PyTree,
+    val: Optional[PyTree],
+    opt: nnx.Optimizer,
+    loss: Callable[[Any, PyTree, Array], Array],
+    n_iter: int,
+    batch_size: int,
+    rng: Array,
+    delta: float = 0.0,
+    patience: int = 0,
+) -> Tuple[M, Tuple[Array, Array]]:
+    """Memory-efficient training loop for large datasets.
+
+    Uses Python for loops instead of nnx.scan to reduce memory usage
+    at the cost of speed. Each training step is still JIT-compiled.
+
+    Parameters
+    ----------
+    tfmpe : TFMPE
+        TFMPE model to train
+    train_tokens : Tokens
+        Training tokens
+    val_tokens : Tokens
+        Validation tokens
+    opt : nnx.Optimizer
+        NNX optimizer instance already initialized with tfmpe
+    n_iter : int
+        Number of training iterations
+    batch_size : int
+        Number of samples per batch
+    rng : PRNGKeyArray
+        Random number generator key
+    delta : float, optional
+        Minimum improvement in training loss to reset patience counter.
+        Default is 0.0 (any improvement counts).
+    patience : int, optional
+        Number of epochs to wait for improvement before stopping.
+        Set to 0 to disable early stopping. Default is 0.
+
+    Returns
+    -------
+    Tuple[TFMPE, Tuple[Array, Array]]
+        Trained TFMPE instance (with best weights if early stopped) and tuple of:
+        - training losses shape (n_epochs,) where n_epochs <= n_iter
+        - validation losses shape (n_epochs,) where n_epochs <= n_iter
+    """
+    n_train = tree.leaves(train)[0].shape[0]
+    n_batches = n_train // batch_size
+
+    # JIT-compiled training step
+    @nnx.jit
+    def train_step(
+        model: nnx.Module,
+        opt_model: nnx.Optimizer,
+        batch: PyTree,
+        rng_key: Array,
+    ) -> Array:
+        def model_loss(model: nnx.Module) -> Array:
+            return loss(
+                model,
+                batch,
+                rng_key,
+            )
+
+        batch_loss, grads = nnx.value_and_grad(model_loss)(model)
+        opt_model.update(model, grads)
+        return batch_loss
+
+    # JIT-compiled validation loss
+    @nnx.jit
+    def compute_val_loss(
+        model: nnx.Module,
+        val: PyTree,
+        rng: Array,
+    ) -> Array:
+        return loss(
+            model,
+            val,
+            rng
+        )
+
+    # Pre-split RNG keys for all epochs
+    epoch_rngs = jr.split(rng, n_iter)
+
+    # Accumulate losses in Python lists
+    train_losses_list: List[Array] = []
+    val_losses_list: List[Array] = []
+
+    # Early stopping state
+    best_train_loss = float('inf')
+    epochs_without_improvement = 0
+    best_state = None
+    early_stopping_enabled = patience > 0
+
+    # Python loop over epochs with progress bar
+    pbar = tqdm(range(n_iter), desc="Training")
+    for epoch in pbar:
+        epoch_rng = epoch_rngs[epoch]
+
+        # Shuffle training data
+        epoch_rng, perm_key = jr.split(epoch_rng)
+        perm = jr.permutation(perm_key, n_train)
+
+        # Generate RNG keys for each batch
+        epoch_rng, batch_rng = jr.split(epoch_rng)
+        batch_rngs = jr.split(batch_rng, n_batches)
+
+        # Accumulate batch losses for this epoch
+        batch_losses: List[Array] = []
+
+        # Python loop over batches
+        for batch_idx in range(n_batches):
+            # Extract batch data
+            start = batch_idx * batch_size
+            end = start + batch_size
+            batch = tree.map(
+                lambda x: x[perm[start:end]],
+                train,
+            )
+
+            # Run JIT-compiled training step
+            batch_loss = train_step(
+                model,
+                opt,
+                batch,
+                batch_rngs[batch_idx]
+            )
+            batch_losses.append(batch_loss)
+
+        # Average training loss across batches
+        train_loss = jnp.mean(jnp.stack(batch_losses))
+        train_losses_list.append(train_loss)
+
+        # Compute validation loss
+        if val is not None:
+            epoch_rng, val_key = jr.split(epoch_rng)
+
+            val_loss = compute_val_loss(model, val, val_key)
+            val_losses_list.append(val_loss)
+
+            # Update progress bar with losses
+            pbar.set_postfix(train_loss=f"{float(train_loss):.4f}", val_loss=f"{float(val_loss):.4f}")
+        pbar.set_postfix(train_loss=f"{float(train_loss):.4f}")
+
+        # Early stopping check
+        if early_stopping_enabled:
+            if best_train_loss - float(train_loss) > delta:
+                # Improvement found
+                best_train_loss = float(train_loss)
+                epochs_without_improvement = 0
+                # Save best model state (deep copy since nnx.state returns live view)
+                best_state = tree.map(jnp.copy, nnx.state(model))
+            else:
+                epochs_without_improvement += 1
+                if epochs_without_improvement >= patience:
+                    # Restore best model and stop
+                    assert best_state is not None
+                    nnx.update(model, best_state)
+                    break
+
+    # Stack losses into arrays (may be shorter than n_iter if early stopped)
+    train_losses = jnp.stack(train_losses_list)
+    if val is not None:
+        val_losses = jnp.stack(val_losses_list)
+    else:
+        val_losses = jnp.array([])
+
+    return model, (train_losses, val_losses)

--- a/tfmpe/nn/transformer/__init__.py
+++ b/tfmpe/nn/transformer/__init__.py
@@ -1,3 +1,9 @@
 """Transformer model."""
 
-__all__ = []
+from .config import TransformerConfig
+from .transformer import Transformer
+
+__all__ = [
+    'TransformerConfig',
+    'Transformer',
+]

--- a/tfmpe/nn/transformer/config.py
+++ b/tfmpe/nn/transformer/config.py
@@ -1,0 +1,66 @@
+"""Configuration for transformer architecture."""
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+from flax import nnx
+
+
+@dataclass
+class TransformerConfig:
+    """Configuration container for transformer architecture parameters.
+
+    This dataclass holds all configuration parameters needed to initialize
+    a transformer model. It provides sensible defaults and validates that
+    the latent dimension is divisible by the number of attention heads.
+
+    Attributes
+    ----------
+    latent_dim : int
+        Hidden dimension size for transformer layers
+    n_encoder : int
+        Number of encoder transformer blocks
+    n_heads : int
+        Number of attention heads in multi-head attention
+    n_ff : int
+        Number of sequential feedforward layers in MLP blocks
+    label_dim : int
+        Dimension for label embeddings
+    label_dim : int
+        Dimension for positional embeddings
+    index_out_dim : int
+        Output dimension for index embeddings
+    dropout : float
+        Dropout rate for regularization
+    activation : Callable
+        Activation function for feedforward layers (e.g., nnx.relu)
+
+    Raises
+    ------
+    ValueError
+        If latent_dim is not divisible by n_heads
+    """
+
+    latent_dim: int = 128
+    n_encoder: int = 2
+    n_heads: int = 4
+    n_ff: int = 2
+    label_dim: int = 32
+    index_out_dim: int = 64
+    pos_dim: int = 8
+    dropout: float = 0.1
+    activation: Callable = field(default_factory=lambda: nnx.relu)
+
+    def __post_init__(self) -> None:
+        """Validate configuration after initialization.
+
+        Raises
+        ------
+        ValueError
+            If latent_dim is not divisible by n_heads
+        """
+        if self.latent_dim % self.n_heads != 0:
+            raise ValueError(
+                f"latent_dim ({self.latent_dim}) must be divisible by "
+                f"n_heads ({self.n_heads})"
+            )

--- a/tfmpe/nn/transformer/config.py
+++ b/tfmpe/nn/transformer/config.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass, field
 from typing import Callable
+from typing import Literal
 
 from flax import nnx
 
@@ -49,6 +50,7 @@ class TransformerConfig:
     index_out_dim: int = 64
     pos_dim: int = 8
     dropout: float = 0.1
+    attention: Literal['linear'] | Literal['softmax'] = 'softmax'
     activation: Callable = field(default_factory=lambda: nnx.relu)
 
     def __post_init__(self) -> None:

--- a/tfmpe/nn/transformer/config.py
+++ b/tfmpe/nn/transformer/config.py
@@ -53,11 +53,11 @@ class TransformerConfig:
     max_positions: int = 128
     group_dim: int = 8
     max_groups: int = 128
-    dropout: float = 0.1
-    attention: Literal['linear'] | Literal['softmax'] = 'softmax'
+    dropout: float = 0.0
+    attention: Literal['linear'] | Literal['softmax'] | Literal['cudnn'] = 'cudnn'
     activation: Callable = field(default_factory=lambda: nnx.relu)
-    ops_dtype: jnp.dtype = jnp.float32
-    sensitive_ops_dtype: jnp.dtype = jnp.float32
+    ops_dtype: jnp.dtype = jnp.bfloat16
+    sensitive_ops_dtype: jnp.dtype = jnp.bfloat16
 
     def __post_init__(self) -> None:
         """Validate configuration after initialization.

--- a/tfmpe/nn/transformer/config.py
+++ b/tfmpe/nn/transformer/config.py
@@ -49,7 +49,9 @@ class TransformerConfig:
     label_dim: int = 32
     index_out_dim: int = 64
     pos_dim: int = 8
+    max_positions: int = 128
     group_dim: int = 8
+    max_groups: int = 128
     dropout: float = 0.1
     attention: Literal['linear'] | Literal['softmax'] = 'softmax'
     activation: Callable = field(default_factory=lambda: nnx.relu)

--- a/tfmpe/nn/transformer/config.py
+++ b/tfmpe/nn/transformer/config.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import Callable
 from typing import Literal
 
+import jax.numpy as jnp
 from flax import nnx
 
 
@@ -55,6 +56,8 @@ class TransformerConfig:
     dropout: float = 0.1
     attention: Literal['linear'] | Literal['softmax'] = 'softmax'
     activation: Callable = field(default_factory=lambda: nnx.relu)
+    ops_dtype: jnp.dtype = jnp.float32
+    sensitive_ops_dtype: jnp.dtype = jnp.float32
 
     def __post_init__(self) -> None:
         """Validate configuration after initialization.

--- a/tfmpe/nn/transformer/config.py
+++ b/tfmpe/nn/transformer/config.py
@@ -49,6 +49,7 @@ class TransformerConfig:
     label_dim: int = 32
     index_out_dim: int = 64
     pos_dim: int = 8
+    group_dim: int = 8
     dropout: float = 0.1
     attention: Literal['linear'] | Literal['softmax'] = 'softmax'
     activation: Callable = field(default_factory=lambda: nnx.relu)

--- a/tfmpe/nn/transformer/embedding.py
+++ b/tfmpe/nn/transformer/embedding.py
@@ -57,7 +57,7 @@ class GaussianFourierEmbedding(nnx.Module):
         Array
             Embedded output, shape (..., out_dim)
         """
-        x = 2 * jnp.pi * jnp.dot(inputs, self.b.value)
+        x = 2 * jnp.pi * jnp.dot(inputs, self.b[...])
         return jnp.concatenate([
             jnp.cos(x),
             jnp.sin(x),

--- a/tfmpe/nn/transformer/embedding.py
+++ b/tfmpe/nn/transformer/embedding.py
@@ -1,0 +1,200 @@
+"""Embedding layers for transformer architecture."""
+
+from jax import numpy as jnp
+from jax import random
+from flax import nnx
+from jaxtyping import Array
+from ...preprocessing.tokens import Tokens
+
+
+class GaussianFourierEmbedding(nnx.Module):
+    """Gaussian Fourier feature embedding for continuous values.
+
+    Maps input features through sin/cos of random Gaussian frequency
+    basis to produce higher-dimensional embeddings.
+
+    Attributes
+    ----------
+    b : nnx.Param
+        Gaussian frequency basis matrix, shape (in_dim, out_dim // 2)
+    """
+
+    def __init__(
+        self,
+        in_dim: int,
+        out_dim: int,
+        rngs: nnx.Rngs,
+    ) -> None:
+        """Initialize Gaussian Fourier embedding.
+
+        Parameters
+        ----------
+        in_dim : int
+            Input feature dimension
+        out_dim : int
+            Output feature dimension (must be even)
+        rngs : Array
+            JAX random key for initialization
+        """
+        b_dim = out_dim // 2
+        self.b = nnx.Param(
+            random.normal(rngs.params(), (in_dim, b_dim))
+        )
+
+    def __call__(self, inputs: Array) -> Array:
+        """Apply Gaussian Fourier embedding.
+
+        Computes concatenation of [cos(2π * inputs @ b),
+        sin(2π * inputs @ b)].
+
+        Parameters
+        ----------
+        inputs : Array
+            Input array, shape (..., in_dim)
+
+        Returns
+        -------
+        Array
+            Embedded output, shape (..., out_dim)
+        """
+        x = 2 * jnp.pi * jnp.dot(inputs, self.b.value)
+        return jnp.concatenate([
+            jnp.cos(x),
+            jnp.sin(x),
+        ], axis=-1)
+
+
+class Embedding(nnx.Module):
+    """Embedding layer for token data.
+
+    Combines value and label embeddings into a unified latent
+    representation.
+
+    Attributes
+    ----------
+    embedding : nnx.Embed
+        Label embedding layer
+    linear : nnx.Linear
+        Linear projection to latent dimension
+    functional_inputs_dim : int
+        Dimension of functional inputs (0 if not used)
+    """
+
+    def __init__(
+        self,
+        value_dim: int,
+        n_labels: int,
+        label_dim: int,
+        pos_dim: int,
+        latent_dim: int,
+        rngs: nnx.Rngs,
+        f_in_in_dim: int = 0,
+        f_in_out_dim: int = 0,
+    ) -> None:
+        """Initialize Embedding layer.
+
+        Parameters
+        ----------
+        value_dim : int
+            Dimension of token values
+        n_labels : int
+            Number of distinct labels
+        label_dim : int
+            Embedding dimension for labels
+        latent_dim : int
+            Target latent dimension
+        rngs : nnx.Rngs
+            JAX random number generator for initialization
+        functional_inputs_dim : int, optional
+            Dimension of functional inputs (0 if not used).
+            Default is 0.
+        """
+
+        self.embedding = nnx.Embed(
+            n_labels,
+            features=label_dim,
+            rngs=rngs,
+        )
+
+        self.pos_emb = GaussianFourierEmbedding(1, pos_dim, rngs)
+
+        if f_in_in_dim > 0:
+            self.f_in_emb = GaussianFourierEmbedding(f_in_in_dim, f_in_out_dim, rngs)
+        else:
+            f_in_out_dim = 0
+
+        # Input dimension: value + label + pos + time + functional_inputs
+        in_dim = value_dim + label_dim + pos_dim + 1 + f_in_out_dim
+
+        self.linear = nnx.Linear(
+            in_dim,
+            latent_dim,
+            rngs=rngs,
+        )
+
+    def __call__(
+        self,
+        tokens: Tokens,
+        time: Array
+    ) -> Array:
+        """Embed token data.
+
+        Parameters
+        ----------
+        tokens : Tokens
+            Token data object containing values, labels, and
+            optional functional inputs
+
+        Returns
+        -------
+        Array
+            Embedded tokens, shape (*sample_shape, n_tokens,
+            latent_dim)
+        """
+        # Extract components from Tokens
+        values = tokens.data
+        labels = tokens.labels
+        functional_inputs = tokens.functional_inputs
+
+        # Embed labels
+        labels_emb = self.embedding(labels)
+
+        # Extract sample and token shapes
+        sample_shape = tokens.sample_shape
+        n_tokens = values.shape[len(tokens.sample_shape)]
+
+        # Expand labels
+        labels_emb = jnp.broadcast_to(
+            labels_emb,
+            sample_shape + (n_tokens,) + (labels_emb.shape[-1],)
+        )
+
+        time_expanded = jnp.broadcast_to(
+            jnp.atleast_1d(time)[..., None, None],
+            sample_shape + (n_tokens, 1),
+        )
+
+        # Compute and embed positions
+        pos_expanded = jnp.broadcast_to(
+            tokens.position[..., None],
+            sample_shape + (n_tokens, 1)
+        )
+        pos_emb = self.pos_emb(pos_expanded)
+
+        # Build concatenation
+        parts = [
+            values,
+            labels_emb,
+            pos_emb,
+            time_expanded
+        ]
+
+        if functional_inputs is not None:
+            parts.append(
+                self.f_in_emb(functional_inputs)
+            )
+
+        x = jnp.concatenate(parts, axis=-1)
+
+        # Apply linear projection
+        return self.linear(x)

--- a/tfmpe/nn/transformer/embedding.py
+++ b/tfmpe/nn/transformer/embedding.py
@@ -24,6 +24,7 @@ class GaussianFourierEmbedding(nnx.Module):
         in_dim: int,
         out_dim: int,
         rngs: nnx.Rngs,
+        dtype: jnp.dtype = jnp.float32,
     ) -> None:
         """Initialize Gaussian Fourier embedding.
 
@@ -36,6 +37,7 @@ class GaussianFourierEmbedding(nnx.Module):
         rngs : Array
             JAX random key for initialization
         """
+        self.dtype = dtype
         b_dim = out_dim // 2
         self.b = nnx.Param(
             random.normal(rngs.params(), (in_dim, b_dim))
@@ -61,7 +63,7 @@ class GaussianFourierEmbedding(nnx.Module):
         return jnp.concatenate([
             jnp.cos(x),
             jnp.sin(x),
-        ], axis=-1)
+        ], axis=-1).astype(self.dtype)
 
 
 class Embedding(nnx.Module):
@@ -93,6 +95,7 @@ class Embedding(nnx.Module):
         f_in_out_dim: int = 0,
         group_dim: int = 0,
         max_groups: int = 128,
+        ops_dtype: jnp.dtype = jnp.float32,
     ) -> None:
         """Initialize Embedding layer.
 
@@ -129,12 +132,14 @@ class Embedding(nnx.Module):
         self.embedding = nnx.Embed(
             n_labels,
             features=label_dim,
+            dtype=ops_dtype,
             rngs=rngs,
         )
 
         self.pos_emb = nnx.Embed(
             max_positions,
             features=pos_dim,
+            dtype=ops_dtype,
             rngs=rngs,
         )
 
@@ -143,11 +148,14 @@ class Embedding(nnx.Module):
             self.group_emb = nnx.Embed(
                 max_groups,
                 features=group_dim,
+                dtype=ops_dtype,
                 rngs=rngs,
             )
 
         if f_in_in_dim > 0:
-            self.f_in_emb = GaussianFourierEmbedding(f_in_in_dim, f_in_out_dim, rngs)
+            self.f_in_emb = GaussianFourierEmbedding(
+                f_in_in_dim, f_in_out_dim, rngs, dtype=ops_dtype,
+            )
         else:
             f_in_out_dim = 0
 
@@ -157,6 +165,7 @@ class Embedding(nnx.Module):
         self.linear = nnx.Linear(
             in_dim,
             latent_dim,
+            dtype=ops_dtype,
             rngs=rngs,
         )
 

--- a/tfmpe/nn/transformer/embedding.py
+++ b/tfmpe/nn/transformer/embedding.py
@@ -90,6 +90,7 @@ class Embedding(nnx.Module):
         rngs: nnx.Rngs,
         f_in_in_dim: int = 0,
         f_in_out_dim: int = 0,
+        group_dim: int = 0,
     ) -> None:
         """Initialize Embedding layer.
 
@@ -108,6 +109,9 @@ class Embedding(nnx.Module):
         functional_inputs_dim : int, optional
             Dimension of functional inputs (0 if not used).
             Default is 0.
+        group_dim : int, optional
+            Dimension for group id embeddings (0 to disable).
+            Default is 0.
         """
 
         self.embedding = nnx.Embed(
@@ -118,13 +122,17 @@ class Embedding(nnx.Module):
 
         self.pos_emb = GaussianFourierEmbedding(1, pos_dim, rngs)
 
+        self.group_dim = group_dim
+        if group_dim > 0:
+            self.group_emb = GaussianFourierEmbedding(1, group_dim, rngs)
+
         if f_in_in_dim > 0:
             self.f_in_emb = GaussianFourierEmbedding(f_in_in_dim, f_in_out_dim, rngs)
         else:
             f_in_out_dim = 0
 
-        # Input dimension: value + label + pos + time + functional_inputs
-        in_dim = value_dim + label_dim + pos_dim + 1 + f_in_out_dim
+        # Input dimension: value + label + pos + time + group + functional_inputs
+        in_dim = value_dim + label_dim + pos_dim + 1 + group_dim + f_in_out_dim
 
         self.linear = nnx.Linear(
             in_dim,
@@ -188,6 +196,14 @@ class Embedding(nnx.Module):
             pos_emb,
             time_expanded
         ]
+
+        # Embed group_id
+        if self.group_dim > 0:
+            group_expanded = jnp.broadcast_to(
+                tokens.group_id[..., None],
+                sample_shape + (n_tokens, 1)
+            )
+            parts.append(self.group_emb(group_expanded))
 
         if functional_inputs is not None:
             parts.append(

--- a/tfmpe/nn/transformer/embedding.py
+++ b/tfmpe/nn/transformer/embedding.py
@@ -86,11 +86,13 @@ class Embedding(nnx.Module):
         n_labels: int,
         label_dim: int,
         pos_dim: int,
+        max_positions: int,
         latent_dim: int,
         rngs: nnx.Rngs,
         f_in_in_dim: int = 0,
         f_in_out_dim: int = 0,
         group_dim: int = 0,
+        max_groups: int = 128,
     ) -> None:
         """Initialize Embedding layer.
 
@@ -102,16 +104,26 @@ class Embedding(nnx.Module):
             Number of distinct labels
         label_dim : int
             Embedding dimension for labels
+        pos_dim : int
+            Embedding dimension for within-group position
+        max_positions : int
+            Maximum number of within-group positions
         latent_dim : int
             Target latent dimension
         rngs : nnx.Rngs
             JAX random number generator for initialization
-        functional_inputs_dim : int, optional
-            Dimension of functional inputs (0 if not used).
+        f_in_in_dim : int, optional
+            Input dimension of functional inputs (0 if not used).
+            Default is 0.
+        f_in_out_dim : int, optional
+            Output dimension of functional input embeddings.
             Default is 0.
         group_dim : int, optional
-            Dimension for group id embeddings (0 to disable).
+            Embedding dimension for group id (0 to disable).
             Default is 0.
+        max_groups : int, optional
+            Maximum number of groups for group id embedding.
+            Default is 128.
         """
 
         self.embedding = nnx.Embed(
@@ -120,11 +132,19 @@ class Embedding(nnx.Module):
             rngs=rngs,
         )
 
-        self.pos_emb = GaussianFourierEmbedding(1, pos_dim, rngs)
+        self.pos_emb = nnx.Embed(
+            max_positions,
+            features=pos_dim,
+            rngs=rngs,
+        )
 
         self.group_dim = group_dim
         if group_dim > 0:
-            self.group_emb = GaussianFourierEmbedding(1, group_dim, rngs)
+            self.group_emb = nnx.Embed(
+                max_groups,
+                features=group_dim,
+                rngs=rngs,
+            )
 
         if f_in_in_dim > 0:
             self.f_in_emb = GaussianFourierEmbedding(f_in_in_dim, f_in_out_dim, rngs)
@@ -182,12 +202,8 @@ class Embedding(nnx.Module):
             sample_shape + (n_tokens, 1),
         )
 
-        # Compute and embed positions
-        pos_expanded = jnp.broadcast_to(
-            tokens.position[..., None],
-            sample_shape + (n_tokens, 1)
-        )
-        pos_emb = self.pos_emb(pos_expanded)
+        # Embed positions (integer indices)
+        pos_emb = self.pos_emb(tokens.position.astype(jnp.int32))
 
         # Build concatenation
         parts = [
@@ -197,13 +213,11 @@ class Embedding(nnx.Module):
             time_expanded
         ]
 
-        # Embed group_id
+        # Embed group_id (integer indices)
         if self.group_dim > 0:
-            group_expanded = jnp.broadcast_to(
-                tokens.group_id[..., None],
-                sample_shape + (n_tokens, 1)
+            parts.append(
+                self.group_emb(tokens.group_id.astype(jnp.int32))
             )
-            parts.append(self.group_emb(group_expanded))
 
         if functional_inputs is not None:
             parts.append(

--- a/tfmpe/nn/transformer/encoder.py
+++ b/tfmpe/nn/transformer/encoder.py
@@ -2,7 +2,6 @@
 
 from typing import Callable, Optional
 
-import jax.numpy as jnp
 from jaxtyping import Array
 from flax import nnx
 

--- a/tfmpe/nn/transformer/encoder.py
+++ b/tfmpe/nn/transformer/encoder.py
@@ -1,0 +1,343 @@
+"""Encoder and decoder blocks for transformer architecture."""
+
+from typing import Callable, Optional
+
+import jax.numpy as jnp
+from jaxtyping import Array
+from flax import nnx
+
+from .config import TransformerConfig
+from .linear_attention import linear_attention
+
+class FFLayer(nnx.Module):
+    """Single feedforward layer with linear, dropout, and activation.
+
+    Attributes
+    ----------
+    linear : nnx.Linear
+        Linear transformation layer
+    dropout : nnx.Dropout
+        Dropout regularization
+    activation : Callable
+        Activation function (e.g., nnx.relu)
+    """
+
+    activation: Callable
+
+    def __init__(
+        self,
+        dim: int,
+        dropout: float,
+        activation: Callable,
+        rngs: nnx.Rngs,
+    ) -> None:
+        """Initialize feedforward layer.
+
+        Parameters
+        ----------
+        dim : int
+            Feature dimension (input and output)
+        dropout : float
+            Dropout rate
+        activation : Callable
+            Activation function
+        rngs : nnx.Rngs
+            Random number generator state
+        """
+        self.linear = nnx.Linear(dim, dim, rngs=rngs)
+        self.dropout = nnx.Dropout(dropout, rngs=rngs)
+        self.activation = activation
+
+    def __call__(self, x: Array) -> Array:
+        """Apply feedforward transformation.
+
+        Parameters
+        ----------
+        x : Array
+            Input array of shape (..., dim)
+
+        Returns
+        -------
+        Array
+            Output array of shape (..., dim)
+        """
+        x = self.linear(x)
+        x = self.dropout(x)
+        x = self.activation(x)
+        return x
+
+
+class MLP(nnx.Module):
+    """Multi-layer feedforward network.
+
+    Applies sequential feedforward layers with dropout and activation
+    functions. Maintains input shape through the network.
+
+    Attributes
+    ----------
+    n_layers : int
+        Number of feedforward layers
+    layers : nnx.Module
+        Vmapped FFLayer modules
+    """
+
+    n_layers: int
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        rngs: nnx.Rngs,
+    ) -> None:
+        """Initialize MLP network.
+
+        Parameters
+        ----------
+        config : TransformerConfig
+            Configuration containing latent_dim, n_ff, dropout, activation
+        rngs : nnx.Rngs
+            Random number generator state
+        """
+        n_ff = config.n_ff
+        dim = config.latent_dim
+        dropout = config.dropout
+        activation = config.activation
+
+        @nnx.split_rngs(splits=n_ff)
+        @nnx.vmap(in_axes=(0,), out_axes=0)
+        def create_layer(rngs: nnx.Rngs) -> FFLayer:
+            """Create a single feedforward layer."""
+            return FFLayer(dim, dropout, activation, rngs=rngs)
+
+        self.layers = create_layer(rngs)
+        self.n_layers = n_ff
+
+    def __call__(self, x: Array) -> Array:
+        """Apply MLP transformation.
+
+        Sequentially applies each feedforward layer, preserving input
+        shape.
+
+        Parameters
+        ----------
+        x : Array
+            Input array of shape (..., latent_dim)
+
+        Returns
+        -------
+        Array
+            Output array of shape (..., latent_dim)
+        """
+
+        @nnx.split_rngs(splits=self.n_layers)
+        @nnx.scan(in_axes=(nnx.Carry, 0), out_axes=nnx.Carry)
+        def forward(
+            x: Array,
+            model: FFLayer,
+        ) -> Array:
+            """Apply a single layer and return updated state."""
+            x = model(x)
+            return x
+
+        return forward(x, self.layers)
+
+
+class EncoderBlock(nnx.Module):
+    """Self-attention transformer encoder block.
+
+    Applies multi-head self-attention followed by feedforward network,
+    with residual connections and layer normalization after each
+    sub-layer.
+
+    Attributes
+    ----------
+    attention : nnx.MultiHeadAttention
+        Multi-head self-attention module
+    att_norm : nnx.LayerNorm
+        Layer normalization after attention
+    mlp : MLP
+        Feedforward network
+    ff_norm : nnx.LayerNorm
+        Layer normalization after feedforward
+    """
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        rngs: nnx.Rngs,
+    ) -> None:
+        """Initialize encoder block.
+
+        Parameters
+        ----------
+        config : TransformerConfig
+            Configuration containing latent_dim, n_heads, dropout
+        rngs : nnx.Rngs
+            Random number generator state
+        """
+        latent_dim = config.latent_dim
+        n_heads = config.n_heads
+
+        self.attention = nnx.MultiHeadAttention(
+            num_heads=n_heads,
+            in_features=latent_dim,
+            qkv_features=latent_dim,
+            use_bias=False,
+            broadcast_dropout=False,
+            dropout_rate=config.dropout,
+            decode=False,
+            attention_fn=linear_attention,
+            rngs=rngs,
+        )
+        self.att_norm = nnx.LayerNorm(
+            num_features=latent_dim,
+            dtype=float,
+            rngs=rngs,
+        )
+        self.mlp = MLP(config=config, rngs=rngs)
+        self.ff_norm = nnx.LayerNorm(
+            num_features=latent_dim,
+            dtype=float,
+            rngs=rngs,
+        )
+
+    def __call__(
+        self,
+        x: Array,
+        mask: Optional[Array] = None,
+        deterministic: bool = False,
+    ) -> Array:
+        """Apply encoder block transformation.
+
+        Applies self-attention with residual connection and layer
+        normalization, followed by feedforward with residual connection
+        and layer normalization.
+
+        Parameters
+        ----------
+        x : Array
+            Input array of shape (..., latent_dim)
+        mask : Optional[Array]
+            Unused. Linear attention does not support masking.
+        deterministic : bool
+            If True, disable dropout for deterministic inference.
+
+        Returns
+        -------
+        Array
+            Output array of shape (..., latent_dim)
+        """
+        # Self-attention with residual and norm
+        attn_out = self.attention(
+            x, x, x, mask=None, deterministic=deterministic
+        )
+        x = x + attn_out
+        x = self.att_norm(x)
+
+        # Feedforward with residual and norm
+        ff_out = self.mlp(x)
+        x = x + ff_out
+        x = self.ff_norm(x)
+
+        return x
+
+class DecoderBlock(nnx.Module):
+    """Cross-attention transformer decoder block.
+
+    Applies multi-head cross-attention between query and context,
+    followed by feedforward network, with residual connections and
+    layer normalization after each sub-layer.
+
+    Attributes
+    ----------
+    attention : nnx.MultiHeadAttention
+        Multi-head cross-attention module
+    att_norm : nnx.LayerNorm
+        Layer normalization after attention
+    mlp : MLP
+        Feedforward network
+    ff_norm : nnx.LayerNorm
+        Layer normalization after feedforward
+    """
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        rngs: nnx.Rngs,
+    ) -> None:
+        """Initialize decoder block.
+
+        Parameters
+        ----------
+        config : TransformerConfig
+            Configuration containing latent_dim, n_heads, dropout
+        rngs : nnx.Rngs
+            Random number generator state
+        """
+        latent_dim = config.latent_dim
+        n_heads = config.n_heads
+
+        self.attention = nnx.MultiHeadAttention(
+            num_heads=n_heads,
+            in_features=latent_dim,
+            qkv_features=latent_dim,
+            use_bias=False,
+            broadcast_dropout=False,
+            dropout_rate=config.dropout,
+            decode=False,
+            attention_fn=linear_attention,
+            rngs=rngs,
+        )
+        self.att_norm = nnx.LayerNorm(
+            num_features=latent_dim,
+            dtype=float,
+            rngs=rngs,
+        )
+        self.mlp = MLP(config=config, rngs=rngs)
+        self.ff_norm = nnx.LayerNorm(
+            num_features=latent_dim,
+            dtype=float,
+            rngs=rngs,
+        )
+
+    def __call__(
+        self,
+        x: Array,
+        context: Array,
+        mask: Optional[Array] = None,
+        deterministic: bool = False,
+    ) -> Array:
+        """Apply decoder block transformation.
+
+        Applies cross-attention with residual connection and layer
+        normalization, followed by feedforward with residual connection
+        and layer normalization.
+
+        Parameters
+        ----------
+        x : Array
+            Query array of shape (..., n_q, latent_dim)
+        context : Array
+            Context (key/value) array of shape (..., n_context, latent_dim)
+        mask : Optional[Array]
+            Unused. Linear attention does not support masking.
+        deterministic : bool
+            If True, disable dropout for deterministic inference.
+
+        Returns
+        -------
+        Array
+            Output array of shape (..., n_q, latent_dim)
+        """
+        # Cross-attention with residual and norm
+        attn_out = self.attention(
+            x, context, context, mask=None, deterministic=deterministic
+        )
+        x = x + attn_out
+        x = self.att_norm(x)
+
+        # Feedforward with residual and norm
+        ff_out = self.mlp(x)
+        x = x + ff_out
+        x = self.ff_norm(x)
+
+        return x

--- a/tfmpe/nn/transformer/encoder.py
+++ b/tfmpe/nn/transformer/encoder.py
@@ -128,7 +128,6 @@ class MLP(nnx.Module):
             Output array of shape (..., latent_dim)
         """
 
-        @nnx.split_rngs(splits=self.n_layers)
         @nnx.scan(in_axes=(nnx.Carry, 0), out_axes=nnx.Carry)
         def forward(
             x: Array,

--- a/tfmpe/nn/transformer/encoder.py
+++ b/tfmpe/nn/transformer/encoder.py
@@ -21,12 +21,19 @@ def cudnn_attention(
 ) -> Array:
     """Flash attention via cuDNN backend.
 
-    Thin wrapper around jax.nn.dot_product_attention that forces
-    the cuDNN implementation and discards Flax-specific kwargs
-    (dropout_rng, dropout_rate, etc.).
+    Accepts either a 1-D integer array of shape (batch,) as seq lengths
+    (varlen path, no dense mask materialized) or a boolean mask
+    (batch, 1, q_len, kv_len) for the standard path.
+    Discards Flax-specific kwargs (dropout_rng, dropout_rate, etc.).
     """
     if mask is not None:
-        mask = mask.astype(jnp.bool_)
+        # Varlen flash attention: seq_lengths avoids any dense mask
+        return jax.nn.dot_product_attention(
+            query, key, value,
+            query_seq_lengths=mask,
+            key_value_seq_lengths=mask,
+            implementation="cudnn",
+        )
     return jax.nn.dot_product_attention(
         query, key, value, mask=mask, implementation="cudnn"
     )

--- a/tfmpe/nn/transformer/encoder.py
+++ b/tfmpe/nn/transformer/encoder.py
@@ -4,6 +4,7 @@ from typing import Callable, Optional
 
 from jaxtyping import Array
 from flax import nnx
+from flax.nnx.nn.attention import dot_product_attention
 
 from .config import TransformerConfig
 from .linear_attention import linear_attention
@@ -175,6 +176,15 @@ class EncoderBlock(nnx.Module):
         latent_dim = config.latent_dim
         n_heads = config.n_heads
 
+        if config.attention == 'softmax':
+            attention_fn = dot_product_attention
+        elif config.attention == 'linear':
+            attention_fn = linear_attention
+        else:
+            raise ValueError(
+                "TransformerConfig specifies unknown attention: {config.attention}"
+            )
+
         self.attention = nnx.MultiHeadAttention(
             num_heads=n_heads,
             in_features=latent_dim,
@@ -183,7 +193,7 @@ class EncoderBlock(nnx.Module):
             broadcast_dropout=False,
             dropout_rate=config.dropout,
             decode=False,
-            attention_fn=linear_attention,
+            attention_fn=attention_fn,
             rngs=rngs,
         )
         self.att_norm = nnx.LayerNorm(
@@ -226,109 +236,7 @@ class EncoderBlock(nnx.Module):
         """
         # Self-attention with residual and norm
         attn_out = self.attention(
-            x, x, x, mask=None, deterministic=deterministic
-        )
-        x = x + attn_out
-        x = self.att_norm(x)
-
-        # Feedforward with residual and norm
-        ff_out = self.mlp(x)
-        x = x + ff_out
-        x = self.ff_norm(x)
-
-        return x
-
-class DecoderBlock(nnx.Module):
-    """Cross-attention transformer decoder block.
-
-    Applies multi-head cross-attention between query and context,
-    followed by feedforward network, with residual connections and
-    layer normalization after each sub-layer.
-
-    Attributes
-    ----------
-    attention : nnx.MultiHeadAttention
-        Multi-head cross-attention module
-    att_norm : nnx.LayerNorm
-        Layer normalization after attention
-    mlp : MLP
-        Feedforward network
-    ff_norm : nnx.LayerNorm
-        Layer normalization after feedforward
-    """
-
-    def __init__(
-        self,
-        config: TransformerConfig,
-        rngs: nnx.Rngs,
-    ) -> None:
-        """Initialize decoder block.
-
-        Parameters
-        ----------
-        config : TransformerConfig
-            Configuration containing latent_dim, n_heads, dropout
-        rngs : nnx.Rngs
-            Random number generator state
-        """
-        latent_dim = config.latent_dim
-        n_heads = config.n_heads
-
-        self.attention = nnx.MultiHeadAttention(
-            num_heads=n_heads,
-            in_features=latent_dim,
-            qkv_features=latent_dim,
-            use_bias=False,
-            broadcast_dropout=False,
-            dropout_rate=config.dropout,
-            decode=False,
-            attention_fn=linear_attention,
-            rngs=rngs,
-        )
-        self.att_norm = nnx.LayerNorm(
-            num_features=latent_dim,
-            dtype=float,
-            rngs=rngs,
-        )
-        self.mlp = MLP(config=config, rngs=rngs)
-        self.ff_norm = nnx.LayerNorm(
-            num_features=latent_dim,
-            dtype=float,
-            rngs=rngs,
-        )
-
-    def __call__(
-        self,
-        x: Array,
-        context: Array,
-        mask: Optional[Array] = None,
-        deterministic: bool = False,
-    ) -> Array:
-        """Apply decoder block transformation.
-
-        Applies cross-attention with residual connection and layer
-        normalization, followed by feedforward with residual connection
-        and layer normalization.
-
-        Parameters
-        ----------
-        x : Array
-            Query array of shape (..., n_q, latent_dim)
-        context : Array
-            Context (key/value) array of shape (..., n_context, latent_dim)
-        mask : Optional[Array]
-            Unused. Linear attention does not support masking.
-        deterministic : bool
-            If True, disable dropout for deterministic inference.
-
-        Returns
-        -------
-        Array
-            Output array of shape (..., n_q, latent_dim)
-        """
-        # Cross-attention with residual and norm
-        attn_out = self.attention(
-            x, context, context, mask=None, deterministic=deterministic
+            x, x, x, mask=mask, deterministic=deterministic
         )
         x = x + attn_out
         x = self.att_norm(x)

--- a/tfmpe/nn/transformer/encoder.py
+++ b/tfmpe/nn/transformer/encoder.py
@@ -2,6 +2,7 @@
 
 from typing import Callable, Optional
 
+import jax.numpy as jnp
 from jaxtyping import Array
 from flax import nnx
 from flax.nnx.nn.attention import dot_product_attention
@@ -30,6 +31,7 @@ class FFLayer(nnx.Module):
         dropout: float,
         activation: Callable,
         rngs: nnx.Rngs,
+        dtype: jnp.dtype = jnp.float32,
     ) -> None:
         """Initialize feedforward layer.
 
@@ -43,8 +45,10 @@ class FFLayer(nnx.Module):
             Activation function
         rngs : nnx.Rngs
             Random number generator state
+        dtype : jnp.dtype
+            Dtype for linear layer parameters
         """
-        self.linear = nnx.Linear(dim, dim, rngs=rngs)
+        self.linear = nnx.Linear(dim, dim, dtype=dtype, rngs=rngs)
         self.dropout = nnx.Dropout(dropout, rngs=rngs)
         self.activation = activation
 
@@ -101,12 +105,13 @@ class MLP(nnx.Module):
         dim = config.latent_dim
         dropout = config.dropout
         activation = config.activation
+        ops_dtype = config.ops_dtype
 
         @nnx.split_rngs(splits=n_ff)
         @nnx.vmap(in_axes=(0,), out_axes=0)
         def create_layer(rngs: nnx.Rngs) -> FFLayer:
             """Create a single feedforward layer."""
-            return FFLayer(dim, dropout, activation, rngs=rngs)
+            return FFLayer(dim, dropout, activation, rngs=rngs, dtype=ops_dtype)
 
         self.layers = create_layer(rngs)
         self.n_layers = n_ff
@@ -185,6 +190,9 @@ class EncoderBlock(nnx.Module):
                 "TransformerConfig specifies unknown attention: {config.attention}"
             )
 
+        self.ops_dtype = config.ops_dtype
+        self.sensitive_ops_dtype = config.sensitive_ops_dtype
+
         self.attention = nnx.MultiHeadAttention(
             num_heads=n_heads,
             in_features=latent_dim,
@@ -193,18 +201,19 @@ class EncoderBlock(nnx.Module):
             broadcast_dropout=False,
             dropout_rate=config.dropout,
             decode=False,
+            dtype=config.sensitive_ops_dtype,
             attention_fn=attention_fn,
             rngs=rngs,
         )
         self.att_norm = nnx.LayerNorm(
             num_features=latent_dim,
-            dtype=float,
+            dtype=config.sensitive_ops_dtype,
             rngs=rngs,
         )
         self.mlp = MLP(config=config, rngs=rngs)
         self.ff_norm = nnx.LayerNorm(
             num_features=latent_dim,
-            dtype=float,
+            dtype=config.sensitive_ops_dtype,
             rngs=rngs,
         )
 
@@ -235,15 +244,17 @@ class EncoderBlock(nnx.Module):
             Output array of shape (..., latent_dim)
         """
         # Self-attention with residual and norm
+        x_op = x.astype(self.ops_dtype)
         attn_out = self.attention(
-            x, x, x, mask=mask, deterministic=deterministic
+            x_op, x_op, x_op, mask=mask, deterministic=deterministic
         )
-        x = x + attn_out
+        x = x.astype(self.sensitive_ops_dtype) + attn_out.astype(self.sensitive_ops_dtype)
         x = self.att_norm(x)
 
         # Feedforward with residual and norm
-        ff_out = self.mlp(x)
-        x = x + ff_out
+        ff_out = self.mlp(x.astype(self.ops_dtype))
+        x = x.astype(self.sensitive_ops_dtype) + ff_out.astype(self.sensitive_ops_dtype)
         x = self.ff_norm(x)
 
-        return x
+        # Cast back to ops_dtype for scan carry compatibility
+        return x.astype(self.ops_dtype)

--- a/tfmpe/nn/transformer/encoder.py
+++ b/tfmpe/nn/transformer/encoder.py
@@ -2,6 +2,7 @@
 
 from typing import Callable, Optional
 
+import jax
 import jax.numpy as jnp
 from jaxtyping import Array
 from flax import nnx
@@ -9,6 +10,26 @@ from flax.nnx.nn.attention import dot_product_attention
 
 from .config import TransformerConfig
 from .linear_attention import linear_attention
+
+
+def cudnn_attention(
+    query: Array,
+    key: Array,
+    value: Array,
+    mask: Array | None = None,
+    **kwargs,
+) -> Array:
+    """Flash attention via cuDNN backend.
+
+    Thin wrapper around jax.nn.dot_product_attention that forces
+    the cuDNN implementation and discards Flax-specific kwargs
+    (dropout_rng, dropout_rate, etc.).
+    """
+    if mask is not None:
+        mask = mask.astype(jnp.bool_)
+    return jax.nn.dot_product_attention(
+        query, key, value, mask=mask, implementation="cudnn"
+    )
 
 class FFLayer(nnx.Module):
     """Single feedforward layer with linear, dropout, and activation.
@@ -134,6 +155,9 @@ class MLP(nnx.Module):
         """
 
         @nnx.scan(in_axes=(nnx.Carry, 0), out_axes=nnx.Carry)
+        @nnx.remat(
+            policy=jax.checkpoint_policies.dots_with_no_batch_dims_saveable,
+        )
         def forward(
             x: Array,
             model: FFLayer,
@@ -185,6 +209,8 @@ class EncoderBlock(nnx.Module):
             attention_fn = dot_product_attention
         elif config.attention == 'linear':
             attention_fn = linear_attention
+        elif config.attention == 'cudnn':
+            attention_fn = cudnn_attention
         else:
             raise ValueError(
                 "TransformerConfig specifies unknown attention: {config.attention}"

--- a/tfmpe/nn/transformer/linear_attention.py
+++ b/tfmpe/nn/transformer/linear_attention.py
@@ -1,0 +1,81 @@
+"""Linear attention implementation."""
+
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array
+from flax.typing import Dtype, PrecisionLike
+from flax.nnx.module import Module
+
+
+def linear_attention(
+    query: Array,
+    key: Array,
+    value: Array,
+    mask: Array | None = None,
+    dropout_rng: Array | None = None,
+    dropout_rate: float = 0.0,
+    broadcast_dropout: bool = True,
+    deterministic: bool = False,
+    dtype: Dtype | None = None,
+    precision: PrecisionLike = None,
+    module: Module | None = None,
+) -> Array:
+    """Basic linear attention (non-causal, parallel form).
+
+    Implements: output = φ(Q)(φ(K)^T V) / (φ(Q) · Σφ(K))
+
+    Uses ELU+1 as the feature map φ to ensure positive values.
+
+    Parameters
+    ----------
+    query : Array
+        Shape [batch..., q_length, num_heads, qk_depth_per_head]
+    key : Array
+        Shape [batch..., kv_length, num_heads, qk_depth_per_head]
+    value : Array
+        Shape [batch..., kv_length, num_heads, v_depth_per_head]
+    mask : None
+        Must be None. Linear attention does not support masking.
+    dropout_rng : Array | None
+        Unused, for interface compatibility.
+    dropout_rate : float
+        Unused, for interface compatibility.
+    broadcast_dropout : bool
+        Unused, for interface compatibility.
+    deterministic : bool
+        Unused, for interface compatibility.
+    dtype : Dtype | None
+        Unused, for interface compatibility.
+    precision : PrecisionLike
+        Precision for einsum operations.
+    module : Module | None
+        Unused, for interface compatibility.
+
+    Returns
+    -------
+    Array
+        Shape [batch..., q_length, num_heads, v_depth_per_head]
+    """
+    assert mask is None, "Linear attention does not support masking"
+
+    # Feature map: ELU + 1 (ensures positive values)
+    def feature_map(x: Array) -> Array:
+        return jax.nn.elu(x) + 1
+
+    q = feature_map(query)
+    k = feature_map(key)
+
+    # KV: φ(K)^T @ V -> [batch..., heads, d, v_d]
+    kv = jnp.einsum('...lhd,...lhv->...hdv', k, value, precision=precision)
+
+    # K sum: Σφ(K) -> [batch..., heads, d]
+    k_sum = jnp.sum(k, axis=-3)
+
+    # Output: φ(Q) @ KV -> [batch..., q_len, heads, v_d]
+    output = jnp.einsum('...qhd,...hdv->...qhv', q, kv, precision=precision)
+
+    # Normalizer: φ(Q) · Σφ(K) -> [batch..., q_len, heads]
+    normalizer = jnp.einsum('...qhd,...hd->...qh', q, k_sum, precision=precision)
+    normalizer = jnp.maximum(normalizer, 1e-6)
+
+    return output / normalizer[..., None]

--- a/tfmpe/nn/transformer/linear_attention.py
+++ b/tfmpe/nn/transformer/linear_attention.py
@@ -64,8 +64,20 @@ def linear_attention(
     k = feature_map(key)
 
     if mask is not None:
-        q = q * mask[..., None]
-        value = value * mask[..., None]
+        # Assume a seperable mask (padding mask) which is
+        # compatible with this simple linear attention
+        q_mask = jnp.swapaxes(
+            jnp.any(mask, axis=-1),
+            -1,
+            -2
+        )
+        kv_mask = jnp.swapaxes(
+            jnp.any(mask, axis=-2),
+            -1,
+            -2
+        )
+        q = q * q_mask[..., None]
+        value = value * kv_mask[..., None]
 
     # KV: φ(K)^T @ V -> [batch..., heads, d, v_d]
     kv = jnp.einsum('...lhd,...lhv->...hdv', k, value, precision=precision)

--- a/tfmpe/nn/transformer/linear_attention.py
+++ b/tfmpe/nn/transformer/linear_attention.py
@@ -56,14 +56,16 @@ def linear_attention(
     Array
         Shape [batch..., q_length, num_heads, v_depth_per_head]
     """
-    assert mask is None, "Linear attention does not support masking"
-
     # Feature map: ELU + 1 (ensures positive values)
     def feature_map(x: Array) -> Array:
         return jax.nn.elu(x) + 1
 
     q = feature_map(query)
     k = feature_map(key)
+
+    if mask is not None:
+        q = q * mask[..., None]
+        value = value * mask[..., None]
 
     # KV: φ(K)^T @ V -> [batch..., heads, d, v_d]
     kv = jnp.einsum('...lhd,...lhv->...hdv', k, value, precision=precision)

--- a/tfmpe/nn/transformer/linear_attention.py
+++ b/tfmpe/nn/transformer/linear_attention.py
@@ -92,4 +92,7 @@ def linear_attention(
     normalizer = jnp.einsum('...qhd,...hd->...qh', q, k_sum, precision=precision)
     normalizer = jnp.maximum(normalizer, 1e-6)
 
-    return output / normalizer[..., None]
+    result = output / normalizer[..., None]
+    if dtype is not None:
+        result = result.astype(dtype)
+    return result

--- a/tfmpe/nn/transformer/transformer.py
+++ b/tfmpe/nn/transformer/transformer.py
@@ -123,7 +123,6 @@ class Transformer(nnx.Module):
         x = self.embedding(tokens, time)
 
         # Apply encoder blocks sequentially via scan
-        @nnx.split_rngs(splits=self.config.n_encoder)
         @nnx.scan(in_axes=(nnx.Carry, 0), out_axes=nnx.Carry)
         def forward(
             x: Array,

--- a/tfmpe/nn/transformer/transformer.py
+++ b/tfmpe/nn/transformer/transformer.py
@@ -1,0 +1,181 @@
+"""Main transformer model for TFMPE."""
+
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array
+from flax import nnx
+
+from .config import TransformerConfig
+from .embedding import Embedding
+from .encoder import EncoderBlock
+from ...preprocessing.tokens import Tokens
+
+
+class Transformer(nnx.Module):
+    """Encoder only transformer for TFMPE.
+
+    Processes context and parameter tokens through separate encoder
+    blocks with shared attention, then decoder blocks with
+    cross-attention.
+
+    Attributes
+    ----------
+    config : TransformerConfig
+        Configuration for transformer architecture
+    embedding : Embedding
+        Embedding layer for token data
+    encoder_blocks : nnx.Module
+        Vmapped encoder blocks
+    decoder_blocks : nnx.Module
+        Vmapped decoder blocks
+    output_linear : nnx.Linear
+        Linear layer projecting from latent_dim to value_dim
+    """
+
+    config: TransformerConfig
+    value_dim: int
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        tokens: Tokens,
+        rngs: nnx.Rngs,
+    ) -> None:
+        """Initialize transformer.
+
+        Deduces value_dim, n_labels, and functional_inputs_dim from
+        tokens.
+
+        Parameters
+        ----------
+        config : TransformerConfig
+            Configuration containing latent_dim, n_encoder, n_decoder,
+            n_heads, n_ff, label_dim, index_out_dim, dropout,
+            activation
+        tokens : Tokens
+            Full Tokens object containing all data
+        rngs : nnx.Rngs
+            JAX random number generators for parameter
+            initialization
+        """
+        self.config = config
+        self.value_dim = tokens.data.shape[-1]
+
+        n_labels = jnp.unique(tokens.labels).shape[0]
+        f_in_in_dim = (
+            tokens.functional_inputs.shape[-1]
+            if tokens.functional_inputs is not None
+            else 0
+        )
+
+        # Create embedding layer
+        self.embedding = Embedding(
+            value_dim=self.value_dim,
+            n_labels=n_labels,
+            label_dim=config.label_dim,
+            pos_dim=config.pos_dim,
+            latent_dim=config.latent_dim,
+            rngs=rngs,
+            f_in_in_dim=f_in_in_dim,
+            f_in_out_dim=config.index_out_dim
+        )
+
+        # Create encoder blocks via vmap
+        @nnx.split_rngs(splits=config.n_encoder)
+        @nnx.vmap(in_axes=(0,), out_axes=0)
+        def create_encoder_block(rngs: nnx.Rngs) -> EncoderBlock:
+            """Create a single encoder block."""
+            return EncoderBlock(config=config, rngs=rngs)
+
+        self.encoder_blocks = create_encoder_block(rngs)
+
+        # Create output linear layer
+        self.output_linear = nnx.Linear(
+            config.latent_dim,
+            self.value_dim,
+            rngs=rngs,
+        )
+
+    def encode(
+        self,
+        tokens: Tokens,
+        time: Array,
+        deterministic: bool = False,
+    ) -> Array:
+        """Encode tokens through encoder blocks.
+
+        Parameters
+        ----------
+        tokens : Tokens
+            Input tokens to encode
+        time : Array
+            Time values, shape (*sample_shape,) or (*sample_shape, 1)
+        deterministic : bool, optional
+            If True, disable dropout. Default is False.
+
+        Returns
+        -------
+        Array
+            Encoded tokens, shape (*sample_shape, n_tokens,
+            latent_dim)
+        """
+        # Embed tokens
+        x = self.embedding(tokens, time)
+
+        # Apply encoder blocks sequentially via scan
+        @nnx.split_rngs(splits=self.config.n_encoder)
+        @nnx.scan(in_axes=(nnx.Carry, 0), out_axes=nnx.Carry)
+        def forward(
+            x: Array,
+            encoder_block: EncoderBlock,
+        ) -> Array:
+            """Apply a single encoder block and return updated state."""
+            x = encoder_block(
+                x,
+                mask=None,
+                deterministic=deterministic,
+            )
+            return x
+
+        x = forward(x, self.encoder_blocks)
+
+        token_dim = len(tokens.sample_shape)
+        return jax.lax.slice_in_dim(
+            x,
+            tokens.partition_idx,
+            None,
+            axis=token_dim
+        )
+
+    def __call__(
+        self,
+        tokens: Tokens,
+        time: Array,
+        deterministic: bool = False,
+    ) -> Array:
+        """Forward pass through transformer.
+
+        Parameters
+        ----------
+        context : Tokens
+            Context tokens to encode
+        params : Tokens
+            Parameter tokens to decode
+        time : Array
+            Time values, shape (*sample_shape,) or (*sample_shape, 1)
+        deterministic : bool, optional
+            If True, disable dropout. Default is False.
+
+        Returns
+        -------
+        Array
+            Output vector field, shape matching params.data
+        """
+        # Encode context
+        output = self.encode(
+            tokens=tokens,
+            time=time,
+            deterministic=deterministic,
+        )
+
+        return self.output_linear(output)

--- a/tfmpe/nn/transformer/transformer.py
+++ b/tfmpe/nn/transformer/transformer.py
@@ -81,6 +81,7 @@ class Transformer(nnx.Module):
             f_in_out_dim=config.index_out_dim,
             group_dim=config.group_dim,
             max_groups=config.max_groups,
+            ops_dtype=config.ops_dtype,
         )
 
         # Create encoder blocks via vmap
@@ -96,6 +97,7 @@ class Transformer(nnx.Module):
         self.output_linear = nnx.Linear(
             config.latent_dim,
             self.value_dim,
+            dtype=config.ops_dtype,
             rngs=rngs,
         )
 

--- a/tfmpe/nn/transformer/transformer.py
+++ b/tfmpe/nn/transformer/transformer.py
@@ -123,6 +123,16 @@ class Transformer(nnx.Module):
         x = self.embedding(tokens, time)
 
         # Apply encoder blocks sequentially via scan
+        if tokens.padding_mask is not None:
+            sample_shape = tokens.sample_shape
+            n_tokens = tokens.data.shape[tokens.sample_ndims]
+            n_heads = self.config.n_heads
+            mask = tokens.padding_mask[:, None, None, :]
+            mask = jnp.broadcast_to(mask, sample_shape + (n_heads, n_tokens, n_tokens))
+        else:
+            mask = None
+
+        # Apply encoder blocks sequentially via scan
         @nnx.scan(in_axes=(nnx.Carry, 0), out_axes=nnx.Carry)
         def forward(
             x: Array,
@@ -131,7 +141,7 @@ class Transformer(nnx.Module):
             """Apply a single encoder block and return updated state."""
             x = encoder_block(
                 x,
-                mask=None,
+                mask=mask,
                 deterministic=deterministic,
             )
             return x

--- a/tfmpe/nn/transformer/transformer.py
+++ b/tfmpe/nn/transformer/transformer.py
@@ -74,11 +74,13 @@ class Transformer(nnx.Module):
             n_labels=n_labels,
             label_dim=config.label_dim,
             pos_dim=config.pos_dim,
+            max_positions=config.max_positions,
             latent_dim=config.latent_dim,
             rngs=rngs,
             f_in_in_dim=f_in_in_dim,
             f_in_out_dim=config.index_out_dim,
             group_dim=config.group_dim,
+            max_groups=config.max_groups,
         )
 
         # Create encoder blocks via vmap

--- a/tfmpe/nn/transformer/transformer.py
+++ b/tfmpe/nn/transformer/transformer.py
@@ -77,7 +77,8 @@ class Transformer(nnx.Module):
             latent_dim=config.latent_dim,
             rngs=rngs,
             f_in_in_dim=f_in_in_dim,
-            f_in_out_dim=config.index_out_dim
+            f_in_out_dim=config.index_out_dim,
+            group_dim=config.group_dim,
         )
 
         # Create encoder blocks via vmap

--- a/tfmpe/nn/transformer/transformer.py
+++ b/tfmpe/nn/transformer/transformer.py
@@ -129,11 +129,13 @@ class Transformer(nnx.Module):
 
         # Apply encoder blocks sequentially via scan
         if tokens.padding_mask is not None:
-            sample_shape = tokens.sample_shape
-            n_tokens = tokens.data.shape[tokens.sample_ndims]
-            n_heads = self.config.n_heads
-            mask = tokens.padding_mask[:, None, None, :]
-            mask = jnp.broadcast_to(mask, sample_shape + (n_heads, n_tokens, n_tokens))
+            if self.config.attention == 'cudnn':
+                # Pass (batch,) seq lengths — varlen flash attention, no dense mask
+                mask = jnp.sum(tokens.padding_mask, axis=-1).astype(jnp.int32)
+            else:
+                # Compact key-padding mask (B, 1, 1, L); XLA broadcasts internally
+                mask = tokens.padding_mask[:, None, None, :]
+
         else:
             mask = None
 

--- a/tfmpe/nn/transformer/transformer.py
+++ b/tfmpe/nn/transformer/transformer.py
@@ -139,6 +139,9 @@ class Transformer(nnx.Module):
 
         # Apply encoder blocks sequentially via scan
         @nnx.scan(in_axes=(nnx.Carry, 0), out_axes=nnx.Carry)
+        @nnx.remat(
+            policy=jax.checkpoint_policies.dots_with_no_batch_dims_saveable,
+        )
         def forward(
             x: Array,
             encoder_block: EncoderBlock,

--- a/tfmpe/preprocessing/combine.py
+++ b/tfmpe/preprocessing/combine.py
@@ -24,8 +24,6 @@ def combine_tokens(tokens1: Tokens, tokens2: Tokens) -> Tokens:
     Tokens
         Combined Tokens with concatenated samples and padded tokens
 
-    Raises
-    ------
     ValueError
         If tokens have incompatible functional_inputs or
         incompatible sample_ndims

--- a/tfmpe/preprocessing/combine.py
+++ b/tfmpe/preprocessing/combine.py
@@ -8,7 +8,9 @@ import dataclasses
 
 from .tokens import Tokens
 
-def combine_tokens(tokens1: Tokens, tokens2: Tokens) -> Tokens:
+def combine_tokens(
+    tokens1: Tokens, tokens2: Tokens, pad_to_even: bool = True
+) -> Tokens:
     """
     Combine two Tokens objects by concatenating samples and padding tokens.
 
@@ -70,6 +72,10 @@ def combine_tokens(tokens1: Tokens, tokens2: Tokens) -> Tokens:
         tokens1.data.shape[tokens1.sample_ndims] - tokens1.partition_idx,
         tokens2.data.shape[tokens2.sample_ndims] - tokens2.partition_idx,
     )
+
+    # Pad target dimension so total sequence length is even (cuDNN flash attn)
+    if pad_to_even and (max_n_condition + max_n_target) % 2 == 1:
+        max_n_target += 1
 
     sample_ndims = tokens1.sample_ndims
 

--- a/tfmpe/preprocessing/tokens.py
+++ b/tfmpe/preprocessing/tokens.py
@@ -120,6 +120,8 @@ class Tokens:
         batch_ndims : Optional[Dict[str, int]], optional
             Number of trailing batch dimensions for each key.
             If None, defaults to 1 for all keys.
+        return_decoder: Optional[bool], optional
+            Whether to return a decoding function
 
         Returns
         -------
@@ -256,6 +258,15 @@ class Tokens:
                 slices,
                 sample_ndims=sample_ndims
             )
+            
+        position = jnp.concatenate([
+            jnp.arange(prod(s.event_shape))
+            for s in slices.values()
+        ])
+        position = jnp.broadcast_to(
+            position.reshape((1,) * sample_ndims + (total_tokens,)),
+            broadcast_shape
+        )
 
         position = jnp.concatenate([
             jnp.arange(prod(s.event_shape))

--- a/tfmpe/preprocessing/tokens.py
+++ b/tfmpe/preprocessing/tokens.py
@@ -63,6 +63,7 @@ class Tokens:
     partition_idx: int
     padding_mask: Optional[Array]
     functional_inputs: Optional[Array]
+    group_id: Array
 
     @property
     def sample_ndims(self) -> int:
@@ -259,21 +260,33 @@ class Tokens:
                 sample_ndims=sample_ndims
             )
             
-        position = jnp.concatenate([
-            jnp.arange(prod(s.event_shape))
-            for s in slices.values()
-        ])
+        # Compute within-group position and group_id
+        position_parts = []
+        group_id_parts = []
+        for s in slices.values():
+            n_tokens_key = prod(s.event_shape)
+            if len(s.event_shape) >= 2:
+                n_groups = s.event_shape[0]
+                inner_dim = prod(s.event_shape[1:])
+                position_parts.append(
+                    jnp.tile(jnp.arange(inner_dim), n_groups)
+                )
+                group_id_parts.append(
+                    jnp.repeat(jnp.arange(n_groups), inner_dim)
+                )
+            else:
+                position_parts.append(jnp.arange(n_tokens_key))
+                group_id_parts.append(jnp.zeros(n_tokens_key))
+
+        position = jnp.concatenate(position_parts)
         position = jnp.broadcast_to(
             position.reshape((1,) * sample_ndims + (total_tokens,)),
             broadcast_shape
         )
 
-        position = jnp.concatenate([
-            jnp.arange(prod(s.event_shape))
-            for s in slices.values()
-        ])
-        position = jnp.broadcast_to(
-            position.reshape((1,) * sample_ndims + (total_tokens,)),
+        group_id = jnp.concatenate(group_id_parts)
+        group_id = jnp.broadcast_to(
+            group_id.reshape((1,) * sample_ndims + (total_tokens,)),
             broadcast_shape
         )
 
@@ -297,6 +310,7 @@ class Tokens:
             condition=condition_values,
             padding_mask=None,
             functional_inputs=func_inputs_flat,
+            group_id=group_id,
             partition_idx=partition_idx
         )
 
@@ -328,6 +342,7 @@ class Tokens:
             self.condition,
             self.padding_mask,
             self.functional_inputs,
+            self.group_id,
         )
         aux_data = {"partition_idx": self.partition_idx}
         return (children, aux_data)
@@ -360,6 +375,7 @@ class Tokens:
             condition,
             padding_mask,
             functional_inputs,
+            group_id,
         ) = children
         return cls(
             data=data,
@@ -368,5 +384,6 @@ class Tokens:
             condition=condition,
             padding_mask=padding_mask,
             functional_inputs=functional_inputs,
+            group_id=group_id,
             partition_idx=aux_data["partition_idx"]
         )

--- a/tfmpe/preprocessing/tokens.py
+++ b/tfmpe/preprocessing/tokens.py
@@ -98,6 +98,7 @@ class Tokens:
         functional_inputs: Optional[Dict[str, Array]] = None,
         sample_ndims: int = 1,
         batch_ndims: Optional[Dict[str, int]] = None,
+        pad_to_even: bool = True,
     ) -> 'Tokens':
         """
         Create Tokens from structured PyTree.
@@ -131,7 +132,7 @@ class Tokens:
         """
         tokens, _ = cls._from_pytree_impl(
             data, condition, labeller, functional_inputs,
-            sample_ndims, batch_ndims
+            sample_ndims, batch_ndims, pad_to_even
         )
         return tokens
 
@@ -144,6 +145,7 @@ class Tokens:
         functional_inputs: Optional[Dict[str, Array]] = None,
         sample_ndims: int = 1,
         batch_ndims: Optional[Dict[str, int]] = None,
+        pad_to_even: bool = True,
     ) -> Tuple['Tokens', Callable[['Tokens'], Dict[str, Array]]]:
         """
         Create Tokens from structured PyTree with a decoder function.
@@ -175,7 +177,7 @@ class Tokens:
         """
         return cls._from_pytree_impl(
             data, condition, labeller, functional_inputs,
-            sample_ndims, batch_ndims
+            sample_ndims, batch_ndims, pad_to_even
         )
 
     @classmethod
@@ -187,6 +189,7 @@ class Tokens:
         functional_inputs: Optional[Dict[str, Array]],
         sample_ndims: int,
         batch_ndims: Optional[Dict[str, int]],
+        pad_to_even: bool = True,
     ) -> Tuple['Tokens', Callable[['Tokens'], Dict[str, Array]]]:
         """
         Internal implementation for from_pytree methods.
@@ -303,20 +306,59 @@ class Tokens:
             broadcast_shape
         )
 
+        padding_mask = None
+
+        # Pad to even sequence length for cuDNN flash attention
+        if pad_to_even and total_tokens % 2 == 1:
+            padding_mask = jnp.ones(broadcast_shape)
+            pad_1d = [(0, 0)] * len(broadcast_shape)
+            pad_1d[sample_ndims] = (0, 1)
+
+            labels = jnp.pad(labels, pad_1d, constant_values=0)
+            position = jnp.pad(position, pad_1d, constant_values=0)
+            condition_values = jnp.pad(
+                condition_values, pad_1d, constant_values=0
+            )
+            group_id = jnp.pad(group_id, pad_1d, constant_values=0)
+            padding_mask = jnp.pad(padding_mask, pad_1d, constant_values=0)
+
+            pad_data = [(0, 0)] * len(flat_data.shape)
+            pad_data[sample_ndims] = (0, 1)
+            flat_data = jnp.pad(flat_data, pad_data, constant_values=0)
+
+            if func_inputs_flat is not None:
+                pad_fi = [(0, 0)] * len(func_inputs_flat.shape)
+                pad_fi[sample_ndims] = (0, 1)
+                func_inputs_flat = jnp.pad(
+                    func_inputs_flat, pad_fi, constant_values=0
+                )
+
         tokens = cls(
             data=flat_data,
             labels=labels,
             position=position,
             condition=condition_values,
-            padding_mask=None,
+            padding_mask=padding_mask,
             functional_inputs=func_inputs_flat,
             group_id=group_id,
             partition_idx=partition_idx
         )
 
+        # Capture original token count for decoder to strip padding
+        orig_total_tokens = total_tokens
+
         def decoder(tokens: 'Tokens') -> Dict[str, Array]:
+            data = tokens.data
+            if data.shape[tokens.sample_ndims] > orig_total_tokens:
+                data = data[
+                    tuple(
+                        slice(None) if i != tokens.sample_ndims
+                        else slice(0, orig_total_tokens)
+                        for i in range(len(data.shape))
+                    )
+                ]
             return decode_pytree(
-                tokens.data,
+                data,
                 slices,
                 tokens.sample_shape,
                 is_subset=False

--- a/tfmpe/preprocessing/utils.py
+++ b/tfmpe/preprocessing/utils.py
@@ -7,7 +7,6 @@ from jaxtyping import Array
 
 import jax.numpy as jnp
 
-
 @dataclass
 class Labeller:
     """
@@ -25,7 +24,6 @@ class Labeller:
         generate label arrays for token data. All values must be
         unique (no collisions allowed).
     """
-
     label_map: Dict[str, int]
 
     def __post_init__(self) -> None:
@@ -134,4 +132,3 @@ class SliceInfo(NamedTuple):
     offset: int
     event_shape: Tuple[int, ...]
     batch_shape: Tuple[int, ...]
-


### PR DESCRIPTION
## Summary
The followung changes as discussed fix the OOM issues for large number of sites.

1. Remove dense dense padding mask that gets fed into cudnn attention.pass (batch,) seq lengths
2. for lc2st a relaisation of an array was occuring when it didnt need to be. We only realise when we get batches.

## Changes
### New Features
1. Remove dense dense padding mask that gets fed into cudnn attention.pass (batch,) seq lengths
2. for lc2st a relaisation of an array was occuring when it didnt need to be. We only realise when we get batches.

### Breaking Changes
<!-- List breaking changes, or write "None" -->

### Fixes
<!-- List bug fixes, or write "None" -->

---

## Reviewer Checklist

### All PRs
- [ ] **Correctness**: Logic is sound and implementation is correct
- [ ] **Testing**: Appropriate tests added/updated
- [ ] **Benchmarking**: Training/sampling speed impact assessed if relevant
- [ ] **Documentation**: Code comments and docs updated where needed

### For AI-Generated PRs
- [ ] **Entropy**: No unnecessary code duplication, verbose implementations,
      or misplaced imports
- [ ] **Test Quality**: Tests genuinely validate intended behavior (check
      `.claude/spec/{feature}/tasks.md` for requirements)
- [ ] **Steering Docs**: Fundamental changes to the repo (if any) are
        reflected in steering documents `.claude/steering/`
